### PR TITLE
Fix conditional in vimrcs/extended.vim

### DIFF
--- a/vimrcs/extended.vim
+++ b/vimrcs/extended.vim
@@ -17,7 +17,7 @@ if has("mac") || has("macunix")
     set gfn=Menlo:h15
 elseif has("win16") || has("win32")
     set gfn=Bitstream\ Vera\ Sans\ Mono:h11
-elseif has("linux")
+elseif has("unix")
     set gfn=Monospace\ 11
 endif
 


### PR DESCRIPTION
Hi Amix!

I found this one while trying the config with gvim:
The font size is not set correctly as supposed to by the config file.
I found that the problem is that a check for feature "linux" is made rather than for "unix".
In the vim help at the feature-list it is listed as "unix" and there is no separate "linux" feature.
