### PR TITLE
Fixed the pathogen error

### DIFF
--- a/vimrcs/plugins_config.vim
+++ b/vimrcs/plugins_config.vim
@@ -8,8 +8,8 @@
 """"""""""""""""""""""""""""""
 " => Load pathogen paths
 """"""""""""""""""""""""""""""
-call pathogen#infect('~/.vim_runtime/sources_forked')
-call pathogen#infect('~/.vim_runtime/sources_non_forked')
+call pathogen#infect('~/.vim_runtime/sources_forked/*')
+call pathogen#infect('~/.vim_runtime/sources_non_forked/*')
 call pathogen#helptags()
 
 """"""""""""""""""""""""""""""


### PR DESCRIPTION
Fixed the error that pathogen.vim throws, when you open up vim. It was a minor directory fix, in the /vimrcs/plugins_config.vim that triggered it.
