### PR TITLE
Fixed issue #48 regarding snippet expansion break

### DIFF
--- a/vimrcs/plugins_config.vim
+++ b/vimrcs/plugins_config.vim
@@ -8,8 +8,8 @@
 """"""""""""""""""""""""""""""
 " => Load pathogen paths
 """"""""""""""""""""""""""""""
-call pathogen#infect('~/.vim_runtime/sources_forked/*')
-call pathogen#infect('~/.vim_runtime/sources_non_forked/*')
+call pathogen#infect('~/.vim_runtime/sources_forked/{}')
+call pathogen#infect('~/.vim_runtime/sources_non_forked/{}')
 call pathogen#helptags()
 
 """"""""""""""""""""""""""""""


### PR DESCRIPTION
The glob pattern of pathogen is {} and not *
The syntax introduced in commit f2d6402 broke the snippet expansion
It is now fixed
