### PR TITLE
Update zenroom2.vim

### DIFF
--- a/sources_non_forked/vim-zenroom2/plugin/zenroom2.vim
+++ b/sources_non_forked/vim-zenroom2/plugin/zenroom2.vim
@@ -62,7 +62,7 @@ function! s:markdown_room()
     exec( "hi StatusLineNC " . l:highlightfgbgcolor )
 endfunction
 
-function! g:zenroom_goyo_before()
+function! g:Zenroom_goyo_before()
     if !has("gui_running")
         return
     endif
@@ -73,7 +73,7 @@ function! g:zenroom_goyo_before()
     endif
 endfunction
 
-function! g:zenroom_goyo_after()
+function! g:Zenroom_goyo_after()
     if !has("gui_running")
         return
     endif
@@ -87,4 +87,4 @@ function! g:zenroom_goyo_after()
     endif
 endfunction
 
-let g:goyo_callbacks = [ function('g:zenroom_goyo_before'), function('g:zenroom_goyo_after') ]
+let g:goyo_callbacks = [ function('g:Zenroom_goyo_before'), function('g:Zenroom_goyo_after') ]


### PR DESCRIPTION
VIM - Vi IMproved 7.4 under cygwin generates the following errors

> Se ha detectado un error al procesar /home/alberto.paz/.vim_runtime/sources_non_forked/vim-zenroom2/plugin/zenroom2.vim:
> línea   65
> E128: Function name must start with a capital or "s:": g:zenroom_goyo_before()
> línea   67
> E133: ":return" no está dentro de una función
> línea   74
> E193: ¡":endfunction" no está dentro de una función!
> línea   76
> E128: Function name must start with a capital or "s:": g:zenroom_goyo_after()
> línea   78
> E133: ":return" no está dentro de una función
> línea   88
> E193: ¡":endfunction" no está dentro de una función!
> línea   90
> E700: Función desconocida: g:zenroom_goyo_before
> E700: Función desconocida: g:zenroom_goyo_after
