### PR TITLE
Make update_plugin.py script compatible with Python 3

### DIFF
--- a/update_plugins.py
+++ b/update_plugins.py
@@ -69,7 +69,7 @@ def download_extract_replace(plugin_name, zip_path, temp_dir, source_dir):
 
     shutil.move(plugin_temp_path, plugin_dest_path)
 
-    print 'Updated %s' % plugin_name
+    print('Updated {0}'.format(plugin_name))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Some brackets must be added when printing update info as **print** became a function in Python 3.

Python 3 (**print** is _function_):

``` python
print(obj)
```

Python 2 (**print** is _operator_):

``` python
print obj
```
