### PR TITLE
Fix zenroom2 function case

### DIFF
--- a/sources_non_forked/vim-zenroom2/plugin/zenroom2.vim
+++ b/sources_non_forked/vim-zenroom2/plugin/zenroom2.vim
@@ -62,7 +62,7 @@ function! s:markdown_room()
     exec( "hi StatusLineNC " . l:highlightfgbgcolor )
 endfunction
 
-function! g:zenroom_goyo_before()
+function! g:Zenroom_goyo_before()
     if !has("gui_running")
         return
     endif
@@ -73,7 +73,7 @@ function! g:zenroom_goyo_before()
     endif
 endfunction
 
-function! g:zenroom_goyo_after()
+function! g:Zenroom_goyo_after()
     if !has("gui_running")
         return
     endif
@@ -87,4 +87,4 @@ function! g:zenroom_goyo_after()
     endif
 endfunction
 
-let g:goyo_callbacks = [ function('g:zenroom_goyo_before'), function('g:zenroom_goyo_after') ]
+let g:goyo_callbacks = [ function('g:Zenroom_goyo_before'), function('g:Zenroom_goyo_after') ]


### PR DESCRIPTION
There's another pull request for this (#89), however, it also includes many other changes. Messages seen under vim >= 7.4
