### PR TITLE
enable my_configs.vim in basic.vim

### DIFF
--- a/vimrcs/basic.vim
+++ b/vimrcs/basic.vim
@@ -65,6 +65,11 @@ nmap <leader>w :w!<cr>
 " (useful for handling the permission-denied error)
 command W w !sudo tee % > /dev/null
 
+" Enable my_configs.vim
+try
+source ~/.vim_runtime/my_configs.vim
+catch
+endtry
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " => VIM user interface


### PR DESCRIPTION
when run install_basic_vimrc.sh, the source ~/.vim_runtime/my_configs.vim is not enabled, please enable it. 
Thank you.
