### PR TITLE
the font name setting for the GTK+ 2 GUI.

### DIFF
--- a/vimrcs/extended.vim
+++ b/vimrcs/extended.vim
@@ -13,8 +13,10 @@ if has("mac") || has("macunix")
     set gfn=Hack:h14,Source\ Code\ Pro:h15,Menlo:h15
 elseif has("win16") || has("win32")
     set gfn=Hack:h14,Source\ Code\ Pro:h12,Bitstream\ Vera\ Sans\ Mono:h11
+elseif has("gui_gtk2")
+    set gfn=Hack\ 14,Source\ Code\ Pro\ 12,Bitstream\ Vera\ Sans\ Mono\ 11
 elseif has("linux")
-    set gfn=Hack:h14,Source\ Code\ Pro:h12,Bitstream\ Vera\ Sans\ Mono:h11
+    set gfn=Hack\ 14,Source\ Code\ Pro\ 12,Bitstream\ Vera\ Sans\ Mono\ 11
 elseif has("unix")
     set gfn=Monospace\ 11
 endif


### PR DESCRIPTION
found this in ```help:gfn```.
>For the GTK+ 2 GUI the font name looks like this: >
>    :set guifont=Andale\ Mono\ 11