### PR TITLE
update : add gitcommit filetype to 50/72 formats

### DIFF
--- a/vimrcs/filetypes.vim
+++ b/vimrcs/filetypes.vim
@@ -54,3 +54,4 @@ endfunction
 au FileType coffee call CoffeeScriptFold()
 
 au FileType gitcommit call setpos('.', [0, 1, 1, 0])
+au Filetype gitcommit setlocal spell textwidth=72


### PR DESCRIPTION
Add `au Filetype gitcommit setlocal spell textwidth=72` to~/.vimrc to add spell checking and automatic wrapping at the recommended 72 columns to commit messages.It's helpful to obey the 50/72 formats - https://github.com/thoughtbot/dotfiles/blob/master/gitmessage