### PR TITLE
yankring_history_dir in the /tmp folder instead of the user folder

### DIFF
--- a/vimrcs/plugins_config.vim
+++ b/vimrcs/plugins_config.vim
@@ -35,7 +35,7 @@ map <leader>f :MRU<CR>
 if has("win16") || has("win32")
     " Don't do anything
 else
-    let g:yankring_history_dir = '~/.vim_runtime/temp_dirs/'
+    let g:yankring_history_dir = '/tmp/.vim_runtime/temp_dirs/'
 endif
 
 


### PR DESCRIPTION
Sometime you are editing some files in a terminal session logged as a different user but keeping the environment for the previous user (su -E). Vim will complain that will not be able to write because the yankring_history_dir is read-only (pointing to the previous user). I'd recommend to use the /tmp folder for the yankring_history.