### PR TITLE
Use ctrlpvim/ctrlp.vim instead of unmaintained kien/ctrlp.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ I recommend reading the docs of these plugins to understand them better. Each of
 * [NERD Tree](https://github.com/scrooloose/nerdtree): A tree explorer plugin for vim
 * [ack.vim](https://github.com/mileszs/ack.vim): Vim plugin for the Perl module / CLI script 'ack'
 * [ag.vim](https://github.com/rking/ag.vim): A much faster Ack
-* [ctrlp.vim](https://github.com/kien/ctrlp.vim): Fuzzy file, buffer, mru and tag finder. In my config it's mapped to `<Ctrl+F>`, because `<Ctrl+P>` is used by YankRing
+* [ctrlp.vim](https://github.com/ctrlpvim/ctrlp.vim): Fuzzy file, buffer, mru and tag finder. In my config it's mapped to `<Ctrl+F>`, because `<Ctrl+P>` is used by YankRing
 * [mru.vim](https://github.com/vim-scripts/mru.vim): Plugin to manage Most Recently Used (MRU) files. Includes my own fork which adds syntax highlighting to MRU. This plugin can be opened with `<leader+f>`
 * [open_file_under_cursor.vim](https://github.com/amix/open_file_under_cursor.vim): Open file under cursor when pressing `gf`
 * [vim-indent-object](https://github.com/michaeljsmith/vim-indent-object): Defines a new text object representing lines of code at the same indent level. Useful for python/vim scripts

--- a/sources_non_forked/ctrlp.vim/.gitignore
+++ b/sources_non_forked/ctrlp.vim/.gitignore
@@ -1,6 +1,0 @@
-*.markdown
-*.zip
-note.txt
-tags
-.hg*
-tmp/*

--- a/sources_non_forked/ctrlp.vim/autoload/ctrlp/autoignore.vim
+++ b/sources_non_forked/ctrlp.vim/autoload/ctrlp/autoignore.vim
@@ -1,0 +1,173 @@
+" =============================================================================
+" File:          autoload/ctrlp/autoignore.vim
+" Description:   Auto-ignore Extension
+" Author:        Ludovic Chabant <github.com/ludovicchabant>
+" =============================================================================
+
+
+" Global Settings {{{
+
+if exists('g:ctrlp_autoignore_loaded') && g:ctrlp_autoignore_loaded
+		\ && !g:ctrlp_autoignore_debug
+	finish
+endif
+let g:ctrlp_autoignore_loaded = 1
+
+if !exists('g:ctrlp_autoignore_debug')
+	let g:ctrlp_autoignore_debug = 0
+endif
+
+if !exists('g:ctrlp_autoignore_trace')
+	let g:ctrlp_autoignore_trace = 0
+endif
+
+" }}}
+
+" Initialization {{{
+
+if !exists('g:ctrlp_custom_ignore')
+	let g:ctrlp_custom_ignore = {}
+endif
+let g:ctrlp_custom_ignore['func'] = 'ctrlp#autoignore#ignore'
+let g:ctrlp_custom_ignore['func-init'] = 'ctrlp#autoignore#ignore_init'
+let g:ctrlp_custom_ignore['func-close'] = 'ctrlp#autoignore#ignore_close'
+
+if !exists('g:ctrlp_root_markers')
+	let g:ctrlp_root_markers = []
+endif
+call add(g:ctrlp_root_markers, '.ctrlpignore')
+
+" }}}
+
+" Internals {{{
+
+function! s:trace(message) abort
+    if g:ctrlp_autoignore_trace
+        echom "ctrlp_autoignore: " . a:message
+    endif
+endfunction
+
+let s:proj_cache = {}
+let s:active_cwd = ''
+let s:active_cwd_len = 0
+let s:active_patterns = []
+let s:changed_wildignore = 0
+let s:prev_wildignore = ''
+
+function! s:load_project_patterns(root_dir) abort
+	let l:ign_path = a:root_dir . '/.ctrlpignore'
+	if !filereadable(l:ign_path)
+		call s:trace("No pattern file at: " . l:ign_path)
+		return []
+	endif
+	let l:cursyntax = 'regexp'
+	let l:knownsyntaxes = ['regexp', 'wildignore']
+	let l:patterns = []
+	let l:lines = readfile(l:ign_path)
+	for line in l:lines
+		" Comment line?
+		if match(line, '\v^\s*$') >= 0 || match(line, '\v^\s*#') >= 0
+			continue
+		endif
+		" Syntax change?
+		let l:matches = matchlist(line, '\v^syntax:\s?(\w+)\s*$')
+		if len(l:matches) > 0
+			let l:cursyntax = l:matches[1]
+			if index(l:knownsyntaxes, l:cursyntax) < 0
+				echoerr "ctrlp_autoignore: Unknown syntax '".l:cursyntax."' in: ".l:ign_path
+			endif
+			continue
+		endif
+		" Patterns!
+		let l:matches = matchlist(line, '\v^((dir|file|link)\:)?(.*)')
+		let l:mtype = l:matches[2]
+		let l:mpat = l:matches[3]
+		call add(l:patterns, {'syn': l:cursyntax, 'type': l:mtype, 'pat': l:mpat})
+	endfor
+	call s:trace("Loaded " . len(l:patterns) . " patterns from: " . l:ign_path)
+	return l:patterns
+endfunction
+
+function! s:get_project_patterns(root_dir) abort
+	let l:ign_path = a:root_dir . '/.ctrlpignore'
+	let l:ign_mtime = getftime(l:ign_path)
+	let l:patterns = get(s:proj_cache, a:root_dir)
+	if type(l:patterns) == type({})
+		" Check that these patterns are still valid.
+		if l:ign_mtime < 0
+			" File got deleted! :(
+			let l:patterns['pats'] = []
+			return l:patterns['pats']
+		elseif l:ign_mtime <= l:patterns['mtime']
+			" File hasn't changed! :)
+			return l:patterns['pats']
+		endif
+	endif
+
+	call s:trace("Loading patterns for project: " . a:root_dir)
+	let l:loaded = s:load_project_patterns(a:root_dir)
+	let s:proj_cache[a:root_dir] = {
+	\'mtime': localtime(),
+	\'pats': l:loaded}
+	return l:loaded
+endfunction
+
+" The custom ignore function that CtrlP will be using in addition to
+" normal pattern-based matching.
+function! ctrlp#autoignore#ignore(item, type) abort
+	let l:cnv_item = tr(strpart(a:item, s:active_cwd_len), "\\", "/")
+	for pat in s:active_patterns
+		if pat['syn'] != 'regexp'
+			continue
+		endif
+		if pat['type'] == '' || pat['type'] == a:type
+			if match(l:cnv_item, pat['pat']) >= 0
+				call s:trace("Ignoring ".l:cnv_item." because of ".pat['pat'])
+				return 1
+			endif
+		endif
+	endfor
+	return 0
+endfunction
+
+function! ctrlp#autoignore#ignore_init() abort
+	let l:root = getcwd()
+	let s:active_cwd = l:root
+	" len+1 is for including the next separator after the root.
+	let s:active_cwd_len = len(l:root) + 1
+	let s:active_patterns = s:get_project_patterns(l:root)
+	call s:trace("Got ".len(s:active_patterns)." patterns for ".l:root)
+
+	let s:changed_wildignore = 0
+	let s:prev_wildignore = &wildignore
+	for pat in s:active_patterns
+		if pat['syn'] == 'wildignore'
+			execute 'set wildignore+='.pat['pat']
+			let s:changed_wildignore = 1
+		endif
+	endfor
+	if s:changed_wildignore
+		call s:trace("Set wildignore to ".&wildignore)
+	endif
+endfunction
+
+function! ctrlp#autoignore#ignore_close() abort
+	if s:changed_wildignore
+		execute 'set wildignore='.s:prev_wildignore
+		let s:prev_wildignore = ''
+		call s:trace("Set wildignore back to ".&wildignore)
+	endif
+endfunction
+
+" List patterns for a given project's root.
+function! ctrlp#autoignore#get_patterns(root_dir) abort
+	let l:patterns = s:get_project_patterns(a:root_dir)
+	for pat in l:patterns
+		let l:prefix = pat['type'] == '' ? '(all)' : pat['type']
+		echom l:prefix . ':' . pat['pat']
+	endfor
+endfunction
+
+" }}}
+
+" vim:fen:fdm=marker:fmr={{{,}}}:fdl=0:fdc=1:ts=2:sw=2:sts=2

--- a/sources_non_forked/ctrlp.vim/autoload/ctrlp/bookmarkdir.vim
+++ b/sources_non_forked/ctrlp.vim/autoload/ctrlp/bookmarkdir.vim
@@ -112,13 +112,20 @@ fu! ctrlp#bookmarkdir#accept(mode, str)
 	en
 endf
 
-fu! ctrlp#bookmarkdir#add(dir, ...)
-	let str = 'Directory to bookmark: '
-	let cwd = a:dir != '' ? a:dir : s:getinput(str, getcwd(), 'dir')
-	if cwd == '' | retu | en
-	let cwd = fnamemodify(cwd, ':p')
-	let name = a:0 && a:1 != '' ? a:1 : s:getinput('Bookmark as: ', cwd)
-	if name == '' | retu | en
+fu! ctrlp#bookmarkdir#add(bang, dir, ...)
+	let ctrlp_tilde_homedir = get(g:, 'ctrlp_tilde_homedir', 0)
+	let cwd = fnamemodify(getcwd(), ctrlp_tilde_homedir ? ':p:~' : ':p')
+	let dir = fnamemodify(a:dir, ctrlp_tilde_homedir ? ':p:~' : ':p')
+	if a:bang == '!'
+		let cwd = dir != '' ? dir : cwd
+		let name = a:0 && a:1 != '' ? a:1 : cwd
+	el
+		let str = 'Directory to bookmark: '
+		let cwd = dir != '' ? dir : s:getinput(str, cwd, 'dir')
+		if cwd == '' | retu | en
+		let name = a:0 && a:1 != '' ? a:1 : s:getinput('Bookmark as: ', cwd)
+		if name == '' | retu | en
+	en
 	let name = tr(name, '	', ' ')
 	cal s:savebookmark(name, cwd)
 	cal s:msg(name, cwd)

--- a/sources_non_forked/ctrlp.vim/autoload/ctrlp/buffertag.vim
+++ b/sources_non_forked/ctrlp.vim/autoload/ctrlp/buffertag.vim
@@ -43,6 +43,7 @@ let s:bins = [
 	\ ]
 
 let s:types = {
+	\ 'ant'    : '%sant%sant%spt',
 	\ 'asm'    : '%sasm%sasm%sdlmt',
 	\ 'aspperl': '%sasp%sasp%sfsv',
 	\ 'aspvbs' : '%sasp%sasp%sfsv',
@@ -52,6 +53,8 @@ let s:types = {
 	\ 'cpp'    : '%sc++%sc++%snvdtcgsuf',
 	\ 'cs'     : '%sc#%sc#%sdtncEgsipm',
 	\ 'cobol'  : '%scobol%scobol%sdfgpPs',
+	\ 'delphi' : '%spascal%spascal%sfp',
+	\ 'dosbatch': '%sdosbatch%sdosbatch%slv',
 	\ 'eiffel' : '%seiffel%seiffel%scf',
 	\ 'erlang' : '%serlang%serlang%sdrmf',
 	\ 'expect' : '%stcl%stcl%scfp',
@@ -62,6 +65,7 @@ let s:types = {
 	\ 'lisp'   : '%slisp%slisp%sf',
 	\ 'lua'    : '%slua%slua%sf',
 	\ 'make'   : '%smake%smake%sm',
+	\ 'matlab' : '%smatlab%smatlab%sf',
 	\ 'ocaml'  : '%socaml%socaml%scmMvtfCre',
 	\ 'pascal' : '%spascal%spascal%sfp',
 	\ 'perl'   : '%sperl%sperl%sclps',
@@ -69,16 +73,20 @@ let s:types = {
 	\ 'python' : '%spython%spython%scmf',
 	\ 'rexx'   : '%srexx%srexx%ss',
 	\ 'ruby'   : '%sruby%sruby%scfFm',
+	\ 'rust'   : '%srust%srust%sfTgsmctid',
 	\ 'scheme' : '%sscheme%sscheme%ssf',
 	\ 'sh'     : '%ssh%ssh%sf',
 	\ 'csh'    : '%ssh%ssh%sf',
 	\ 'zsh'    : '%ssh%ssh%sf',
+	\ 'scala'  : '%sscala%sscala%sctTmlp',
 	\ 'slang'  : '%sslang%sslang%snf',
 	\ 'sml'    : '%ssml%ssml%secsrtvf',
 	\ 'sql'    : '%ssql%ssql%scFPrstTvfp',
+	\ 'tex'    : '%stex%stex%sipcsubPGl',
 	\ 'tcl'    : '%stcl%stcl%scfmp',
 	\ 'vera'   : '%svera%svera%scdefgmpPtTvx',
 	\ 'verilog': '%sverilog%sverilog%smcPertwpvf',
+	\ 'vhdl'   : '%svhdl%svhdl%sPctTrefp',
 	\ 'vim'    : '%svim%svim%savf',
 	\ 'yacc'   : '%syacc%syacc%sl',
 	\ }
@@ -130,7 +138,7 @@ fu! s:exectags(cmd)
 endf
 
 fu! s:exectagsonfile(fname, ftype)
-	let [ags, ft] = ['-f - --sort=no --excmd=pattern --fields=nKs ', a:ftype]
+	let [ags, ft] = ['-f - --sort=no --excmd=pattern --fields=nKs --extra= ', a:ftype]
 	if type(s:types[ft]) == 1
 		let ags .= s:types[ft]
 		let bin = s:bin
@@ -151,7 +159,11 @@ fu! s:esctagscmd(bin, args, ...)
 		let [ssl, &ssl] = [&ssl, 0]
 	en
 	let fname = a:0 ? shellescape(a:1) : ''
-	let cmd = shellescape(a:bin).' '.a:args.' '.fname
+	if  (has('win32') || has('win64'))
+		let cmd = a:bin.' '.a:args.' '.fname
+	else
+		let cmd = shellescape(a:bin).' '.a:args.' '.fname
+	endif
 	if &sh =~ 'cmd\.exe'
 		let cmd = substitute(cmd, '[&()@^<>|]', '^\0', 'g')
 	en

--- a/sources_non_forked/ctrlp.vim/autoload/ctrlp/mrufiles.vim
+++ b/sources_non_forked/ctrlp.vim/autoload/ctrlp/mrufiles.vim
@@ -6,6 +6,7 @@
 
 " Static variables {{{1
 let [s:mrbs, s:mrufs] = [[], []]
+let s:mruf_map_string = '!stridx(v:val, cwd) ? strpart(v:val, idx) : v:val'
 
 fu! ctrlp#mrufiles#opts()
 	let [pref, opts] = ['g:ctrlp_mruf_', {
@@ -15,6 +16,7 @@ fu! ctrlp#mrufiles#opts()
 		\ 'case_sensitive': ['s:cseno', 1],
 		\ 'relative': ['s:re', 0],
 		\ 'save_on_update': ['s:soup', 1],
+		\ 'map_string': ['g:ctrlp_mruf_map_string', s:mruf_map_string],
 		\ }]
 	for [ke, va] in items(opts)
 		let [{va[0]}, {pref.ke}] = [pref.ke, exists(pref.ke) ? {pref.ke} : va[1]]
@@ -51,7 +53,7 @@ fu! s:reformat(mrufs, ...)
 		let cwd = tr(cwd, '\', '/')
 		cal map(a:mrufs, 'tr(v:val, "\\", "/")')
 	en
-	retu map(a:mrufs, '!stridx(v:val, cwd) ? strpart(v:val, idx) : v:val')
+	retu map(a:mrufs, g:ctrlp_mruf_map_string)
 endf
 
 fu! s:record(bufnr)
@@ -66,10 +68,12 @@ fu! s:record(bufnr)
 endf
 
 fu! s:addtomrufs(fname)
-	let fn = fnamemodify(a:fname, ':p')
+	let fn = fnamemodify(a:fname, get(g:, 'ctrlp_tilde_homedir', 0) ? ':p:~' : ':p')
 	let fn = exists('+ssl') ? tr(fn, '/', '\') : fn
+	let abs_fn = fnamemodify(fn,':p')
 	if ( !empty({s:in}) && fn !~# {s:in} ) || ( !empty({s:ex}) && fn =~# {s:ex} )
-		\ || !empty(getbufvar('^'.fn.'$', '&bt')) || !filereadable(fn) | retu
+		\ || !empty(getbufvar('^' . abs_fn . '$', '&bt')) || !filereadable(abs_fn)
+		retu
 	en
 	let idx = index(s:mrufs, fn, 0, !{s:cseno})
 	if idx
@@ -143,7 +147,7 @@ fu! ctrlp#mrufiles#init()
 	let s:locked = 0
 	aug CtrlPMRUF
 		au!
-		au BufAdd,BufEnter,BufLeave,BufWritePost * cal s:record(expand('<abuf>', 1))
+		au BufWinEnter,BufWinLeave,BufWritePost * cal s:record(expand('<abuf>', 1))
 		au QuickFixCmdPre  *vimgrep* let s:locked = 1
 		au QuickFixCmdPost *vimgrep* let s:locked = 0
 		au VimLeavePre * cal s:savetofile(s:mergelists())

--- a/sources_non_forked/ctrlp.vim/autoload/ctrlp/tag.vim
+++ b/sources_non_forked/ctrlp.vim/autoload/ctrlp/tag.vim
@@ -21,7 +21,7 @@ cal add(g:ctrlp_ext_vars, {
 
 let s:id = g:ctrlp_builtins + len(g:ctrlp_ext_vars)
 " Utilities {{{1
-fu! s:findcount(str)
+fu! s:findcount(str, tgaddr)
 	let [tg, ofname] = split(a:str, '\t\+\ze[^\t]\+$')
 	let tgs = taglist('^'.tg.'$')
 	if len(tgs) < 2
@@ -48,7 +48,13 @@ fu! s:findcount(str)
 	for tgi in ntgs
 		let cnt += 1
 		if tgi["filename"] == ofname
-			let [fnd, pos] = [0, cnt]
+			if a:tgaddr != ""
+				if a:tgaddr == tgi["cmd"]
+					let [fnd, pos] = [0, cnt]
+				en
+			else
+				let [fnd, pos] = [0, cnt]
+			en
 		en
 	endfo
 	retu [1, fnd, pos, len(ctgs)]
@@ -92,8 +98,9 @@ endf
 
 fu! ctrlp#tag#accept(mode, str)
 	cal ctrlp#exit()
+	let tgaddr = matchstr(a:str, '^[^\t]\+\t\+[^\t]\+\t\zs[^\t]\{-1,}\ze\%(;"\)\?\t')
 	let str = matchstr(a:str, '^[^\t]\+\t\+[^\t]\+\ze\t')
-	let [tg, fdcnt] = [split(str, '^[^\t]\+\zs\t')[0], s:findcount(str)]
+	let [tg, fdcnt] = [split(str, '^[^\t]\+\zs\t')[0], s:findcount(str, tgaddr)]
 	let cmds = {
 		\ 't': ['tab sp', 'tab stj'],
 		\ 'h': ['sp', 'stj'],
@@ -121,6 +128,7 @@ fu! ctrlp#tag#accept(mode, str)
 		en
 		cal feedkeys(":".cmd." ".tg."\r".ext, 'nt')
 	en
+	cal feedkeys('zvzz', 'nt')
 	cal ctrlp#setlcdir()
 endf
 

--- a/sources_non_forked/ctrlp.vim/doc/ctrlp.cnx
+++ b/sources_non_forked/ctrlp.vim/doc/ctrlp.cnx
@@ -1,0 +1,1570 @@
+*ctrlp.txt*       模糊的 文件, 缓冲区, 最近最多使用, 标签, ... 检索. v1.79
+*CtrlP* *ControlP* *'ctrlp'* *'ctrl-p'*
+===============================================================================
+#                                                                             #
+#          :::::::: ::::::::::: :::::::::  :::             :::::::::          #
+#         :+:    :+:    :+:     :+:    :+: :+:             :+:    :+:         #
+#         +:+           +:+     +:+    +:+ +:+             +:+    +:+         #
+#         +#+           +#+     +#++:++#:  +#+             +#++:++#+          #
+#         +#+           +#+     +#+    +#+ +#+             +#+                #
+#         #+#    #+#    #+#     #+#    #+# #+#             #+#                #
+#          ########     ###     ###    ### ##########      ###                #
+#                                                                             #
+===============================================================================
+名词对照（译注）
+
+  buffer:缓冲区                    mapping:按键绑定
+     mru:最近最多使用               prompt:提示符面板
+     tag:标签                          tab:页签
+     tab:制表符
+
+===============================================================================
+内容                                                            *ctrlp-content*
+
+    1. 介绍.............................................|ctrlp-intro|
+    2. 选项.............................................|ctrlp-options|
+    3. 命令.............................................|ctrlp-commands|
+    4. 按键绑定.........................................|ctrlp-mappings|
+    5. 输入格式.........................................|ctrlp-input-formats|
+    6. 扩展.............................................|ctrlp-extensions|
+
+===============================================================================
+介绍                                                              *ctrlp-intro*
+
+带有直观接口的全路径模糊文件, 缓冲区, 最近最多使用, 标签, ... 检索。
+使用纯净的Vimscript编写，可以运行在MacVim，gVim和版本号7.0以上的Vim中。
+全面支持Vim的正则表达式 |regexp| 作为搜索模式，内建最近最多使用文件监测，
+项目根目录定位和更多特性。
+
+开启可选的扩展（标记，目录，rtscript...），参考 |ctrlp-extensions| 。
+
+===============================================================================
+OPTIONS                                                         *ctrlp-options*
+
+总览:~
+
+  |loaded_ctrlp|................禁用插件。
+  |ctrlp_map|...................默认按键绑定。
+  |ctrlp_cmd|...................默认按键绑定调用的命令。
+  |ctrlp_by_filename|...........是否默认开启文件名模式。
+  |ctrlp_regexp|................是否默认开启正则表达式模式。
+  |ctrlp_match_window|..........匹配窗口的显示位置。
+  |ctrlp_switch_buffer|.........如果文件已在缓冲区中打开，跳转到该打开的缓冲区。
+  |ctrlp_reuse_window|..........重用特殊窗口（帮助、快速修复 |quickfix| ，等等）。
+  |ctrlp_tabpage_position|......新标签页出现的位置。
+  |ctrlp_working_path_mode|.....如何设置CtrlP的本地工作目录。
+  |ctrlp_root_markers|..........额外的，高优先级的根目录标识。
+  |ctrlp_use_caching|...........针对每个会话，设置是否开启缓存的。
+  |ctrlp_clear_cache_on_exit|...退出Vim后是否保留缓存。
+  |ctrlp_cache_dir|.............缓存目录的位置。
+  |ctrlp_show_hidden|...........是否显示隐藏文件和隐藏文件夹。
+  |ctrlp_custom_ignore|.........使用 |globpath()| 时自定义忽略的文件或目录。
+  |ctrlp_max_files|.............扫描文件的最大数目。
+  |ctrlp_max_depth|.............扫描目录的最大层数。
+  |ctrlp_user_command|..........使用外部的扫描工具。
+  |ctrlp_max_history|...........历史提示符面板中保留的最大条目数。
+  |ctrlp_open_new_file|.........由<c-y>创建的文件的打开方式。
+  |ctrlp_open_multiple_files|...由<c-z>选择的文件的打开方式。
+  |ctrlp_arg_map|...............是否拦截<c-y> 和 <c-o> 命令。
+  |ctrlp_follow_symlinks|.......是否跟随链接。
+  |ctrlp_lazy_update|...........停止输入时才更新。
+  |ctrlp_default_input|.........为提示符面板提供一个种子。
+  |ctrlp_abbrev|................输入缩写。
+  |ctrlp_key_loop|..............为多字节输入开启输入事件循环。
+  |ctrlp_prompt_mappings|.......改变提示符面板内部的按键绑定。
+  |ctrlp_line_prefix|...........ctrlp 窗口中为每一行添加前缀。
+  |ctrlp_open_single_match|.....当只有一个候选时自动接受。
+  |ctrlp_brief_prompt|..........提示符为空的时候使用<bs>退出 CtrlP。
+  |ctrlp_match_current_file|....在匹配条目中包含当前文件。
+
+  最近最多使用模式:
+  |ctrlp_mruf_max|..............记录的最近最多使用的最大数据。
+  |ctrlp_mruf_exclude|..........需要被排除的文件。
+  |ctrlp_mruf_include|..........需要被记录的文件。
+  |ctrlp_mruf_relative|.........只显示在工作目录内的最近最多使用。
+  |ctrlp_tilde_homedir|.........保存 home 目录中的 MRU 的目录路径为波浪扩展的形式 ~/。
+  |ctrlp_mruf_default_order|....禁用排序。
+  |ctrlp_mruf_case_sensitive|...最近最多使用文件是否大小写敏感。
+  |ctrlp_mruf_save_on_update|...只要有一个新的条目添加，就保存到磁盘。
+
+  缓冲模式:
+  |ctrlp_bufname_mod|...........文件名部分修饰符。
+  |ctrlp_bufpath_mod|...........文件路径部分修饰符。
+
+  缓冲标签模式: (开启此模式，参考 |ctrlp-extensions| )
+  |g:ctrlp_buftag_ctags_bin|....兼容的ctags二进制程序的位置。
+  |g:ctrlp_buftag_systemenc|....ctags命令的编码。
+  |g:ctrlp_buftag_types|........添加新的文件类型和设置命令行参数。
+
+  高级选项:
+  |ctrlp_open_func|.............使用自定义的打开文件的函数。
+  |ctrlp_status_func|...........改变CtrlP的两个状态栏
+  |ctrlp_buffer_func|...........在CtrlP的缓冲区内调用自定义的函数。
+  |ctrlp_match_func|............替换内建的匹配算法。
+
+-------------------------------------------------------------------------------
+详细描述和默认值:~
+
+                                                                *'g:ctrlp_map'*
+使用该选项来改变普通模式 |Normal| 下调用CtrlP的按键绑定: >
+  let g:ctrlp_map = '<c-p>'
+<
+
+                                                                *'g:ctrlp_cmd'*
+
+设置当按下上面的按键绑定时，使用的默认打开命令: >
+  let g:ctrlp_cmd = 'CtrlP'
+<
+
+                                                             *'g:loaded_ctrlp'*
+使用该选项完全禁用插件: >
+  let g:loaded_ctrlp = 1
+<
+
+                                                        *'g:ctrlp_by_filename'*
+修改该选项为1，设置默认为按文件名搜索（否则为全路径）: >
+  let g:ctrlp_by_filename = 0
+<
+在提示符面板内可以使用 <c-d> 来切换。
+
+                                                             *'g:ctrlp_regexp'*
+修改该选项为1，设置默认为使用正则表达式匹配。: >
+  let g:ctrlp_regexp = 0
+<
+在提示符面板内可以使用 <c-r> 来切换。
+
+                                                       *'g:ctrlp_match_window'*
+改变匹配窗口的位置，结果的排列顺序，最小和最大高度: >
+  let g:ctrlp_match_window = ''
+<
+例子: >
+  let g:ctrlp_match_window = 'bottom,order:btt,min:1,max:10,results:10'
+<
+位置: (默认:底部)
+  top - 在屏幕顶部显示匹配窗口。
+  bottom - 在屏幕底部显示匹配窗口。
+
+结果的排列顺序: (默认: btt)
+  order:ttb - 从顶部到底部。
+  order:btt - 从底部到顶部。
+
+最小和最大高度:
+  min:{n} - 最少显示 {n} 行 (默认: 1).
+  max:{n} - 最多显示 {n} 行 (默认: 10).
+
+结果集的最大数目:
+  results:{n} - 列出最多 {n} 条结果 (默认: 和最大高度同步).
+
+注意: 当一个设置项没有被设置时，将会使用默认值。
+
+                                                      *'g:ctrlp_switch_buffer'*
+当尝试打开一个文件时，如果它已经在某个窗口被打开，CtrlP会尝试跳到那个窗口，而
+不是新打开一个实例。: >
+  let g:ctrlp_switch_buffer = 'Et'
+<
+  e - 当 <cr> 被按下时跳转，但是只跳转到当前页签内的窗口内。
+  t - 当 <c-t> 被按下时跳转, 但是只跳转到其它标签的窗口内。
+  v - 类似 "e", 但是当 <c-v> 被按下时跳转。
+  h - 类似 "e", 但是当 <c-x> 被按下时跳转。
+  E, T, V, H - 行为类似 "e", "t", "v", and "h", 但是跳转到任何地方的窗口中。
+  0 或者 <empty> - 禁用这项功能。
+
+                                                       *'g:ctrlp_reuse_window'*
+当使用 <cr> 打开新文件时，CtrlP避免在插件，帮助，快速修复创建的窗口中打开该文
+件。使用该选项来设置一些例外: >
+  let g:ctrlp_reuse_window = 'netrw'
+<
+接受的值可以为特殊缓冲区的名字的一部分，文件类型或者缓冲区类型使用正则表达式来
+指定匹配模式。
+例子: >
+  let g:ctrlp_reuse_window = 'netrw\|help\|quickfix'
+<
+
+                                                   *'g:ctrlp_tabpage_position'*
+新打开页签的位置: >
+  let g:ctrlp_tabpage_position = 'ac'
+<
+  a - 后面。
+  b - 前面。
+  c - 当前页签。
+  l - 最后一个页签。
+  f - 第一个页签。
+
+                                                  *'g:ctrlp_working_path_mode'*
+当启动时，CtrlP依据这个变量来设置它的工作目录: >
+  let g:ctrlp_working_path_mode = 'ra'
+<
+  c - 当前文件所在的目录。
+  a - 当前文件所在的目录，除非这个目录为当前工作目录的子目录
+  r - 包含下列文件或者目录的最近的祖先目录:
+      .git .hg .svn .bzr _darcs
+  w - 用来修饰r：使用当前工作目录而不是当前文件所在目录进行查找
+  0 或者 <empty> - 禁用这项功能。
+
+注意 #1: 如果 "a" 或者 "c" 和 "r"一起被包含，当无法找到根目录时使用 "a" 或者 
+"c" 的行为（作为备选）。
+
+注意 #2: 你可以在每个缓冲区内使用 |b:var| 来设置该选项。
+
+                                                       *'g:ctrlp_root_markers'*
+使用该选项来设置自定义的根目录标记作为对默认标记(.hg, .svn, .bzr, and _darcs)
+的补充。自定义的标记具有优先权: >
+  let g:ctrlp_root_markers = ['']
+<
+注意: 你可以在每个缓冲区内使用 |b:var| 来设置该选项。
+
+                                                        *'g:ctrlp_use_caching'*
+启用/禁用每个会话的缓存: >
+  let g:ctrlp_use_caching = 1
+<
+  0 - 禁用缓存。
+  1 - 启用缓存。
+  n - 当大于1时，禁用缓存，使用该数值作为重新启用缓存的限制条件。
+
+注意: 当在CtrlP中时你可以使用 <F5> 来快速的清除缓存。
+
+                                                *'g:ctrlp_clear_cache_on_exit'*
+设置该选项为0通过退出Vim时不删除缓存文件来启用跨会话的缓存: >
+  let g:ctrlp_clear_cache_on_exit = 1
+<
+
+                                                          *'g:ctrlp_cache_dir'*
+设置存储缓存文件的目录: >
+  let g:ctrlp_cache_dir = $HOME.'/.cache/ctrlp'
+<
+
+                                                        *'g:ctrlp_show_hidden'*
+如果你想CtrlP扫描隐藏文件和目录，设置该选项为1: >
+  let g:ctrlp_show_hidden = 0
+<
+注意: 当命令使用 |g:ctrlp_user_command| 定义时该选项无效。
+
+                                                           *'ctrlp-wildignore'*
+你可以使用Vim的 |'wildignore'| 来从结果集中排序文件或目录。
+例子: >
+  " 排除版本控制文件
+  set wildignore+=*/.git/*,*/.hg/*,*/.svn/*        " Linux/MacOSX
+  set wildignore+=*\\.git\\*,*\\.hg\\*,*\\.svn\\*  " Windows ('noshellslash')
+<
+注意 #1: 每个目录设置前的字符 `*/` 是必须的。
+
+注意 #2: |wildignore| 影响 |expand()| ， |globpath()| 和 |glob()| 的结果，这些函数被很
+多插件用来在系统中执行查找。（例如和版本控制系统有关的插件在查找.git/、.hg/等，
+一些其他插件用来在Windows上查找外部的*.exe工具），所以要修改 |wildignore| 时请先
+考虑清楚。
+
+                                                      *'g:ctrlp_custom_ignore'*
+作为对 |'wildignore'| 的补充，用来设置你只是想在CtrlP中隐藏的文件和目录。使用正
+则表达式来指定匹配模式: >
+  let g:ctrlp_custom_ignore = ''
+<
+例子: >
+  let g:ctrlp_custom_ignore = '\v[\/]\.(git|hg|svn)$'
+  let g:ctrlp_custom_ignore = {
+    \ 'dir':  '\v[\/]\.(git|hg|svn)$',
+    \ 'file': '\v\.(exe|so|dll)$',
+    \ 'link': 'SOME_BAD_SYMBOLIC_LINKS',
+    \ }
+  let g:ctrlp_custom_ignore = {
+    \ 'file': '\v(\.cpp|\.h|\.hh|\.cxx)@<!$'
+    \ }
+  let g:ctrlp_custom_ignore = {
+    \ 'func': 'some#custom#match_function'
+    \ }
+<
+注意 #1: 默认情况下， |wildignore| 和 |g:ctrlp_custom_ignore| 只在 |globpath()| 被用
+来扫描文件的情况下使用，这样这些选项在那些使用 |g:ctrlp_user_command| 定义的命
+令中不会生效。
+
+注意 #2: 当改变选项的变量类型时，记得先 |:unlet| ，或者重启Vim来避免这个错误：
+"E706: Variable type mismatch" 。
+
+注意 #3: 当使用函数来忽略类型时，你必须提供CtrlP可以调用的函数的全名。建议使用
+自动加载的函数。函数必须接受两个参数，要匹配的条目和接受的类型，类型可以是目
+录、文件和链接。如果条目被忽略，函数需要返回1，反之，返回0。
+
+                                                          *'g:ctrlp_max_files'*
+扫描文件的最大数量，设置为0时不进行限制: >
+  let g:ctrlp_max_files = 10000
+<
+注意: 当命令使用 |g:ctrlp_user_command| 定义时该选项无效。
+
+                                                          *'g:ctrlp_max_depth'*
+目录树递归的最大层数: >
+  let g:ctrlp_max_depth = 40
+<
+注意: 当命令使用 |g:ctrlp_user_command| 定义时该选项无效。
+
+                                                       *'g:ctrlp_user_command'*
+指定用来代替Vim的 |globpath()| 的外部工具来列出文件，使用 %s 代表目标目录: >
+  let g:ctrlp_user_command = ''
+<
+例子: >
+  let g:ctrlp_user_command = 'find %s -type f'       " MacOSX/Linux
+  let g:ctrlp_user_command = 'dir %s /-n /b /s /a-d' " Windows
+<
+你也可以使用 'grep', 'findstr' 或者其它东西来过滤结果集。
+例子: >
+  let g:ctrlp_user_command =
+    \ 'find %s -type f | grep -v -P "\.jpg$|/tmp/"'          " MacOSX/Linux
+  let g:ctrlp_user_command =
+    \ 'dir %s /-n /b /s /a-d | findstr /v /l ".jpg \\tmp\\"' " Windows
+<
+在扫描一个大型项目时，在仓库目录中使用版本控制系统的列出命令会加快扫描速度: >
+  let g:ctrlp_user_command = [root_marker, listing_command, fallback_command]
+  let g:ctrlp_user_command = {
+    \ 'types': {
+      \ 1: [root_marker_1, listing_command_1],
+      \ n: [root_marker_n, listing_command_n],
+      \ },
+    \ 'fallback': fallback_command,
+    \ 'ignore': 0 or 1
+    \ }
+<
+一些例子: >
+  " 单个版本控制系统，列出命令不会列出没有被追踪的文件:
+  let g:ctrlp_user_command = ['.git', 'cd %s && git ls-files']
+  let g:ctrlp_user_command = ['.hg', 'hg --cwd %s locate -I .']
+
+  " 多个版本控制系统:
+  let g:ctrlp_user_command = {
+    \ 'types': {
+      \ 1: ['.git', 'cd %s && git ls-files'],
+      \ 2: ['.hg', 'hg --cwd %s locate -I .'],
+      \ },
+    \ 'fallback': 'find %s -type f'
+    \ }
+
+  " 单个版本控制系统，列出命令列出没有被追踪的文件（较慢）:
+  let g:ctrlp_user_command =
+    \ ['.git', 'cd %s && git ls-files -co --exclude-standard']
+
+  let g:ctrlp_user_command =
+    \ ['.hg', 'hg --cwd %s status -numac -I . $(hg root)'] " MacOSX/Linux
+
+  let g:ctrlp_user_command = ['.hg', 'for /f "tokens=1" %%a in (''hg root'') '
+    \ . 'do hg --cwd %s status -numac -I . %%a']           " Windows
+<
+注意 #1: 在 |Dictionary| 格式, 'fallback' 和 'ignore' 是可选的，在 |List| 格式，
+备选命令是可选的。
+
+注意 #2: 如果备选命令是空的或者属性 'fallback' 没有定义，当扫描仓库之外目录时，
+|globpath()| 会被使用。
+
+注意 #3: 除非使用了 |Dictionary| 格式并且 'ignore' 被定义并且设置为1，当这些自
+定义的命令被使用时 |wildignore| 和 |g:ctrlp_custom_ignore| 选项不会生效。没有出现
+时，'ignore' 被默认设置为0来保留使用外部命令的性能优势。
+
+注意 #4: 当改变了选项的变量类型时，记得先 |:unlet| ，或者重启Vim来避免这个错误：
+"E706: Variable type mismatch" 。
+
+注意 #5: 你可以在每个缓冲区内使用 |b:var| 来设置该选项。
+
+                                                        *'g:ctrlp_max_history'*
+你希望CtrlP记录的用户输入历史的最大数目。默认值是Vim的全局选项 |'history'| : >
+  let g:ctrlp_max_history = &history
+<
+设置为0来禁用提示符面板的历史。使用 <c-n> 和 <c-p> 来浏览历史。
+
+                                                      *'g:ctrlp_open_new_file'*
+使用该选项指定当使用 <c-y> 打开新建的文件时，文件的打开方式: >
+  let g:ctrlp_open_new_file = 'v'
+<
+  t - 在新页签中。
+  h - 在新的水平分割窗口。
+  v - 在新的竖直分割窗口。
+  r - 在当前窗口。
+
+                                                *'g:ctrlp_open_multiple_files'*
+如果非0， 会启用使用 <c-z> 和 <c-o> 打开多个文件: >
+  let g:ctrlp_open_multiple_files = 'v'
+<
+例子: >
+  let g:ctrlp_open_multiple_files = '2vjr'
+<
+对于数字:
+  - 如果指定，会被用来作为打开文件时创建的窗口或者页签的最大数量（剩余的会在隐
+    藏的缓冲区中打开）。
+  - 如果没有指定，<c-o> 会打开所有文件，每个在一个新的窗口或者页签中。
+
+对于字母:
+  t - 每个文件在一个新页签中。
+  h - 每个文件在一个新的水平分割窗口中。
+  v - 每个文件在一个新的竖直分割窗口中。
+  i - 所有的文件在隐藏的缓冲区中。
+  j - 打开以后，跳转到第一个打开的页签或者窗口。
+  r - 在当前窗口打开第一个文件，其他文件根据同时出现的"h"，"v"和"t"中的一个，
+      在新的分割窗口或者页签中打开。
+
+                                                            *'g:ctrlp_arg_map'*
+当设置为1时， <c-o> 和 <c-y> 会接收一个额外的键值作为参数，来覆盖默认行为: >
+  let g:ctrlp_arg_map = 0
+<
+按下 <c-o> 或者 <c-y> 会提示一次按键。按键可以是:
+  t - 在新标签页中打开。
+  h - 每个文件在一个新的水平分割窗口中。
+  v - 每个文件在一个新的竖直分割窗口中。
+  i - 所有的文件在隐藏的缓冲区中（只有 <c-o> 生效）。
+  c - 清楚标记的文件（只有 <c-o> 生效）。
+  r - 在当前窗口中打开（只有 <c-y> 生效）。
+  <esc>, <c-c>, <c-u> - 取消并且回到提示符面板。
+  <cr> - 使用 |g:ctrlp_open_new_file| 和 |g:ctrlp_open_multiple_files| 指定的默
+         认行为。
+
+
+                                                    *'g:ctrlp_follow_symlinks'*
+如果非0，当列出文件时CtrlP会跟随链接: >
+  let g:ctrlp_follow_symlinks = 0
+<
+  0 - 不要跟随链接。
+  1 - 跟随但是忽略内部循环的链接，避免重复。
+  2 - 无差别的跟随所有链接。
+
+注意: 当命令使用 |g:ctrlp_user_command| 定义时该选项无效。
+
+                                                        *'g:ctrlp_lazy_update'*
+设置为1将开启延迟更新特性：只在输入停止一个确定的时间后才更新匹配窗口: >
+  let g:ctrlp_lazy_update = 0
+<
+如果设置为1，在250毫秒后更新。如果大于1，数字会被作为延迟时间使用。
+
+                                                      *'g:ctrlp_default_input'*
+设置为1将为提示符面板提供当前文件的相对路径作为种子: >
+  let g:ctrlp_default_input = 0
+<
+如果不指定1或0，如果选项的值是字符串，会被用来作为默认输入: >
+  let g:ctrlp_default_input = 'anystring'
+<
+这个选项可以和 |g:ctrlp_open_single_match| 配合使用。
+
+
+                                                 *'g:ctrlp_match_current_file'*
+在匹配条目中包含当前文件:
+  let g:ctrlp_match_current_file = 1
+
+默认情况下，当前文件不包含在列表中。
+
+注意: 当使用 |g:ctrlp_match_func| 时不会应用这个选项。
+
+
+                                                             *'g:ctrlp_abbrev'*
+定义可以在提示面包内被扩展（内部的或者可见的）的输入缩写: >
+  let g:ctrlp_abbrev = {}
+<
+例子: >
+  let g:ctrlp_abbrev = {
+    \ 'gmode': 'i',
+    \ 'abbrevs': [
+      \ {
+        \ 'pattern': '^cd b',
+        \ 'expanded': '@cd ~/.vim/bundle',
+        \ 'mode': 'pfrz',
+      \ },
+      \ {
+        \ 'pattern': '\(^@.\+\|\\\@<!:.\+\)\@<! ',
+        \ 'expanded': '.\{-}',
+        \ 'mode': 'pfr',
+      \ },
+      \ {
+        \ 'pattern': '\\\@<!:.\+\zs\\\@<! ',
+        \ 'expanded': '\ ',
+        \ 'mode': 'pfz',
+      \ },
+      \ ]
+    \ }
+<
+字符串 'pattern' 是使用正则表达式来匹配输入的匹配模式。扩展后就像扩展后的字符串
+在提示符面板中被输入了一样。
+
+对于 'gmode' （可选的）:
+  i - 内部扩展（默认）。
+  t - 插入扩展结果到提示符面板，就像你自己输入的一样。
+  k - 当非关键字的字符被输入时，插入扩展结果到提示符面板。只在"t"也出现时生效。
+
+对于 'mode' （对于每个条目，可选的）:
+  f - 只应用于文件名模式。
+  p - 只应用于全路径模式。
+  r - 只应用于正则表达式模式。
+  z - 只应用于模糊模式。
+  n - 只应用于使用 <c-y> 创建新文件时（使用扩展后的字符串作为文件名）。
+  c - 当使用 <tab> 自动补全目录名时（在自动补全之前立即扩展模式）。
+  <empty> 或者未定义 - 总是启用。
+
+注意: 缩写条目按顺序求值，后求值的条目会覆盖先求值的条目；当 'gmode' 为"t"时，
+包括他自己。
+
+                                                           *'g:ctrlp_key_loop'*
+一个实验性的特性。设置该选项为1将为多字节字符开启输入事件循环: >
+  let g:ctrlp_key_loop = 0
+<
+注意 #1: 当设置时，该选项会重置 |g:ctrlp_lazy_update| 选项。
+
+注意 #2: 你可以在提示符面板使用自定义的按键绑定切换这个特性: >
+  let g:ctrlp_prompt_mappings = { 'ToggleKeyLoop()': ['<F3>'] }
+<
+
+                                                    *'g:ctrlp_prompt_mappings'*
+使用该选项来自定义CtrlP的提示窗口内的按键绑定为你喜欢的方式。你只需要保留你改
+变值（在[]内部）的行: >
+  let g:ctrlp_prompt_mappings = {
+    \ 'PrtBS()':              ['<bs>', '<c-]>'],
+    \ 'PrtDelete()':          ['<del>'],
+    \ 'PrtDeleteWord()':      ['<c-w>'],
+    \ 'PrtClear()':           ['<c-u>'],
+    \ 'PrtSelectMove("j")':   ['<c-j>', '<down>'],
+    \ 'PrtSelectMove("k")':   ['<c-k>', '<up>'],
+    \ 'PrtSelectMove("t")':   ['<Home>', '<kHome>'],
+    \ 'PrtSelectMove("b")':   ['<End>', '<kEnd>'],
+    \ 'PrtSelectMove("u")':   ['<PageUp>', '<kPageUp>'],
+    \ 'PrtSelectMove("d")':   ['<PageDown>', '<kPageDown>'],
+    \ 'PrtHistory(-1)':       ['<c-n>'],
+    \ 'PrtHistory(1)':        ['<c-p>'],
+    \ 'AcceptSelection("e")': ['<cr>', '<2-LeftMouse>'],
+    \ 'AcceptSelection("h")': ['<c-x>', '<c-cr>', '<c-s>'],
+    \ 'AcceptSelection("t")': ['<c-t>'],
+    \ 'AcceptSelection("v")': ['<c-v>', '<RightMouse>'],
+    \ 'ToggleFocus()':        ['<s-tab>'],
+    \ 'ToggleRegex()':        ['<c-r>'],
+    \ 'ToggleByFname()':      ['<c-d>'],
+    \ 'ToggleType(1)':        ['<c-f>', '<c-up>'],
+    \ 'ToggleType(-1)':       ['<c-b>', '<c-down>'],
+    \ 'PrtExpandDir()':       ['<tab>'],
+    \ 'PrtInsert("c")':       ['<MiddleMouse>', '<insert>'],
+    \ 'PrtInsert()':          ['<c-\>'],
+    \ 'PrtCurStart()':        ['<c-a>'],
+    \ 'PrtCurEnd()':          ['<c-e>'],
+    \ 'PrtCurLeft()':         ['<c-h>', '<left>', '<c-^>'],
+    \ 'PrtCurRight()':        ['<c-l>', '<right>'],
+    \ 'PrtClearCache()':      ['<F5>'],
+    \ 'PrtDeleteEnt()':       ['<F7>'],
+    \ 'CreateNewFile()':      ['<c-y>'],
+    \ 'MarkToOpen()':         ['<c-z>'],
+    \ 'OpenMulti()':          ['<c-o>'],
+    \ 'PrtExit()':            ['<esc>', '<c-c>', '<c-g>'],
+    \ }
+<
+注意: 如果按 <bs> 后光标向左移动一个字符而不是删除一个字符，在你的.vimrc中添加
+下面的设置来禁用插件默认的 <c-h> 绑定: >
+  let g:ctrlp_prompt_mappings = { 'PrtCurLeft()': ['<left>', '<c-^>'] }
+<
+
+                                                    *'g:ctrlp_line_prefix'*
+这个前缀会被加到ctrlp的条目列表中每一行的前面。
+默认值: >
+  let g:ctrlp_line_prefix = '> '
+<
+
+                                                    *'g:ctrlp_open_single_match'*
+当CtrlP处于列表中配置的模式中时，如果只有一个候选条目，CtrlP会直接接受该条目。
+例子: >
+  let g:ctrlp_open_single_match = ['buffer tags', 'buffer']
+<
+目前这个选项的作用是和 |g:ctrlp_default_input| 一起，使用类似下面的函数，在使用
+前设置，使用完后还原： >
+  fu! <SID>tagsUnderCursor()
+    try
+      let default_input_save = get(g:, 'ctrlp_default_input', '')
+      let g:ctrlp_default_input = expand('<cword>')
+      CtrlPBufTagAll
+    finally
+      if exists('default_input_save')
+        let g:ctrlp_default_input = default_input_save
+      endif
+    endtry
+  endfu
+>
+<
+----------------------------------------
+MRU mode options:~
+
+                                                           *'g:ctrlp_mruf_max'*
+指定你希望CtrlP记录的最近打开的文件历史的数目: >
+  let g:ctrlp_mruf_max = 250
+<
+
+                                                       *'g:ctrlp_mruf_exclude'*
+你不希望CtrlP记录的文件。使用正则表达式来指定模式: >
+  let g:ctrlp_mruf_exclude = ''
+<
+例子: >
+  let g:ctrlp_mruf_exclude = '/tmp/.*\|/temp/.*' " MacOSX/Linux
+  let g:ctrlp_mruf_exclude = '^C:\\dev\\tmp\\.*' " Windows
+<
+
+                                                       *'g:ctrlp_mruf_include'*
+如果你想让CtrlP只记录某些文件，在这里指定: >
+  let g:ctrlp_mruf_include = ''
+<
+例子: >
+  let g:ctrlp_mruf_include = '\.py$\|\.rb$'
+<
+                                                       *'g:ctrlp_tilde_homedir'*
+将这个选项设置为1来把所有的 MRU 文件路径中 $HOME 目录下的 $HOME/$filepath 保存
+为 ~/$filepath ，而不是 $HOME/$filepath : >
+  let g:ctrlp_tilde_homedir = 0
+<
+注意: 对所有通过 :CtrlPBookmarkDirAdd! 保存的也有效
+
+                                                      *'g:ctrlp_mruf_relative'*
+设置该选项为1将只显示在当前工作目录内的最近最多使用文件: >
+  let g:ctrlp_mruf_relative = 0
+<
+注意: 你可以在提示符面板使用自定义的按键绑定切换这个特性: >
+  let g:ctrlp_prompt_mappings = { 'ToggleMRURelative()': ['<F2>'] }
+<
+
+                                                 *'g:ctrlp_mruf_default_order'*
+设置该选项为1将在最近最多使用模式搜索时禁用排序: >
+  let g:ctrlp_mruf_default_order = 0
+<
+
+                                                *'g:ctrlp_mruf_case_sensitive'*
+将该选项和你的文件系统大小写敏感性保持一致来避免重复的最近最多使用条目: >
+  let g:ctrlp_mruf_case_sensitive = 1
+<
+
+                                                *'g:ctrlp_mruf_save_on_update'*
+设置该选项为 0 禁止 CtrlP 每当有一个新条目增加就把最近最多使用列表保存到磁盘
+文件，而是在退出Vim时才保存: >
+  let g:ctrlp_mruf_save_on_update = 1
+<
+                                                *'g:ctrlp_bufname_mod'*
+根据修饰符修改文件名部分。参见 |filename-modifiers| 。 >
+  let g:ctrlp_bufname_mod = ':t'
+<
+                                                *'g:ctrlp_bufpath_mod'*
+根据修饰符修改文件路径部分。参见 |filename-modifiers| 。 >
+  let g:ctrlp_bufpath_mod = ':~:.:h'
+<
+----------------------------------------
+高级选项:~
+
+                                                          *'g:ctrlp_open_func'*
+使用一个自定义函数来打开选定的文件: >
+  let g:ctrlp_open_func = {}
+<
+例子: >
+  let g:ctrlp_open_func = {
+    \ 'files'     : 'Function_Name_1',
+    \ 'buffers'   : 'Function_Name_2',
+    \ 'mru files' : 'Function_Name_3',
+    \ }
+<
+函数结构: >
+  function! Function_Name(action, line)
+    " 参数:
+    " |
+    " +- a:action : 打开的动作:
+    " |             + 'e' : 用户按下 <cr>  (默认)
+    " |             + 'h' : 用户按下 <c-x> (默认)
+    " |             + 'v' : 用户按下 <c-v> (默认)
+    " |             + 't' : 用户按下 <c-t> (默认)
+    " |             + 'x' : 用户使用 <c-o> 终端对话框 (默认) 选择"e[x]ternal"。
+    " |
+    " +- a:line   : 选择的文件。
+
+  endfunction
+<
+注意: 当使用<c-z> 和 <c-o>打开多个文件时无效。
+
+例子: 当 <c-t> 被按下时在默认浏览器中打开HTML文件，否则在Vim中打开 >
+  function! HTMLOpenFunc(action, line)
+    if a:action =~ '^[tx]$' && fnamemodify(a:line, ':e') =~? '^html\?$'
+
+      " 获取文件名
+      let filename = fnameescape(fnamemodify(a:line, ':p'))
+
+      " 关闭CtrlP
+      call ctrlp#exit()
+
+      " 打开文件
+      silent! execute '!xdg-open' filename
+
+    elseif a:action == 'x' && fnamemodify(a:line, ':e') !~? '^html\?$'
+
+      " 不是HTML文件，再次模拟 <c-o> 按键并且等待新的输入
+      call feedkeys("\<c-o>")
+
+    else
+
+      " 使用CtrlP的默认的打开文件的函数
+      call call('ctrlp#acceptfile', [a:action, a:line])
+
+    endif
+  endfunction
+
+  let g:ctrlp_open_func = { 'files': 'HTMLOpenFunc' }
+<
+
+                                                        *'g:ctrlp_status_func'*
+为CtrlP窗口使用自定义的状态栏: >
+  let g:ctrlp_status_func = {}
+<
+例子: >
+  let g:ctrlp_status_func = {
+    \ 'main': 'Function_Name_1',
+    \ 'prog': 'Function_Name_2',
+    \ }
+<
+函数结构: >
+  " 主状态栏
+  function! Function_Name_1(focus, byfname, regex, prev, item, next, marked)
+    " 参数:
+    " |
+    " +- a:focus   : 提示符面板的焦点: "prt" 或者 "win"。
+    " |
+    " +- a:byfname : 在文件名模式还是全路径模式: "file" 或者 "path"。
+    " |
+    " +- a:regex   : 是否在正则表达式模式: 1 or 0。
+    " |
+    " +- a:prev    : 前一个搜索模式。
+    " |
+    " +- a:item    : 当前的搜索模式。
+    " |
+    " +- a:next    : 下一个搜索模式。
+    " |
+    " +- a:marked  : 被标记文件的数目，或者一个逗号分隔的被标记的文件名列表。
+
+    return full_statusline
+  endfunction
+
+  " 状态栏进度条
+  function! Function_Name_2(str)
+    " a:str : 一个当前已扫描的文件数，或者一个当前扫描目录和用户命令的字符串。
+
+    return full_statusline
+  endfunction
+<
+一个可用的例子，参见 https://gist.github.com/1610859 。
+
+                                                        *'g:ctrlp_buffer_func'*
+指定一个会在启动或者退出CtrlP缓冲区时被调用的函数: >
+  let g:ctrlp_buffer_func = {}
+<
+例子: >
+  let g:ctrlp_buffer_func = {
+    \ 'enter': 'Function_Name_1',
+    \ 'exit':  'Function_Name_2',
+    \ }
+<
+
+                                                         *'g:ctrlp_match_func'*
+为CtrlP设置一个额外的模糊匹配函数: >
+  let g:ctrlp_match_func = {}
+<
+例子: >
+  let g:ctrlp_match_func = { 'match': 'Function_Name' }
+<
+函数结构: >
+  function! Function_Name(items, str, limit, mmode, ispath, crfile, regex)
+    " 参数:
+    " |
+    " +- a:items  : 搜索条目的全列表。
+    " |
+    " +- a:str    : 用户输入的字符串。
+    " |
+    " +- a:limit  : 匹配窗口的最大高度。可以用来限制返回的条目数量。
+    " |
+    " +- a:mmode  : 在匹配模式。可以是下列字符串之一:
+    " |             + "full-line": 匹配整行。
+    " |             + "filename-only": 只匹配文件名。
+    " |             + "first-non-tab": 匹配到第一个制表符。
+    " |             + "until-last-tab": 匹配到最后一个制表符。
+    " |
+    " +- a:ispath : 搜索文件，缓冲区，最近最多使用，混合，目录和rtscript模.
+    " |             式时为1。其它为0。
+    " |
+    " +- a:crfile : 当前窗口中的文件。当a:ispath为1时应该被搜索结果排除在外
+    " |
+    " +- a:regex  : 是否在正则表达式模式: 1 or 0.
+
+    return list_of_matched_items
+  endfunction
+<
+
+注意: 你可以通过 { 'arg_type': 'dict' } 扩展上面的任何选项，这样就可以通过
+一个字典类型的参数来传递所有的函数参数。使用参数名作为字典的键值。
+
+例子: >
+  let g:ctrlp_status_func = {
+    \ 'arg_type' : 'dict',
+    \ 'enter': 'Function_Name_1',
+    \ 'exit':  'Function_Name_2',
+    \ }
+
+  function! Function_Name_1(dict)
+    " where dict == {
+    " \ 'focus':   value,
+    " \ 'byfname': value,
+    " \ 'regex':   value,
+    " \ ...
+    " }
+  endfunction
+<
+                                                       *'g:ctrlp_brief_prompt'*
+当设置为 1 时, 提示符后为空时按 <bs> 会退出 CtrlP 。
+
+                                                          *ctrlp-default-value*
+另外，你可以使用下面的方式来改变默认值。
+例子: >
+  let g:ctrlp_path_nolim = 1
+
+这样可以让无限制模式匹配“路径”类型。
+===============================================================================
+命令                                                           *ctrlp-commands*
+
+                                                                       *:CtrlP*
+:CtrlP [起始目录]
+   用文件搜索模式打开CtrlP。
+
+   如果没有给定参数，|g:ctrlp_working_path_mode| 会被用来决定起始目录。
+
+   在输入时你可以使用 <tab> 自动补全[起始目录]。
+
+                                                                 *:CtrlPBuffer*
+:CtrlPBuffer
+   用缓冲区搜索模式打开CtrlP。
+
+                                                                    *:CtrlPMRU*
+:CtrlPMRU
+   用最近最多使用模式打开CtrlP。
+
+                                                               *:CtrlPLastMode*
+:CtrlPLastMode [--dir]
+   用上一次使用的模式打开CtrlP。当提供了"--dir"参数，也重用上一次的工作目录。
+
+                                                                   *:CtrlPRoot*
+:CtrlPRoot
+    行为类似使用了 |g:ctrlp_working_path_mode| = 'r' 并且忽略了该变量的当前值的
+    |:CtrlP| 命令。
+
+                                                             *:CtrlPClearCache*
+:CtrlPClearCache
+   清除当前工作目录的缓存。和在CtrlP内按 <F5> 效果一样。
+   使用 |g:ctrlp_use_caching| 来启用或禁用缓存。
+
+                                                         *:CtrlPClearAllCaches*
+:CtrlPClearAllCaches
+   删除在 |g:ctrlp_cache_dir| 中定义的缓存目录中的所有缓存文件。
+
+-------------------------------------------------------------------------------
+由扩展提供的命令参见 |ctrlp-extensions| 。
+
+===============================================================================
+按键绑定                                                        *ctrlp-mappings*
+
+                                                                *'ctrlp-<c-p>'*
+<c-p>
+   普通模式 |Normal| 下默认以文件搜索模式打开CtrlP提示符面板。
+
+----------------------------------------
+已经在提示符面板中:~
+
+  <c-d>
+    在全路径搜索和文件名搜索间切换。
+    注意: 在文件名搜索模式，提示符面板的提示符是'>d>'，而不是'>>>'
+
+  <c-r>                                                    *'ctrlp-fullregexp'*
+    在字符串搜索模式和正则表达式模式之间切换。
+    注意: 在全正则表达式模式，提示符面板的提示符是'r>>'，而不是'>>>'
+
+    详细参见: |input-formats| （指引）和 |g:ctrlp_regexp_search| 选项。
+
+  <c-f>, 'forward' 前进
+  <c-up>
+    切换到序列里面的 'next' 后一个搜索模式。
+
+  <c-b>, 'backward' 后退
+  <c-down>
+    切换到序列里面的 'previous' 前一个搜索模式。
+
+  <tab>                                                *'ctrlp-autocompletion'*
+    自动补全在提示符面板的当前工作路径中的目录名。
+
+  <s-tab>
+    在匹配窗口和提示符面板之间切换焦点。
+
+  <esc>,
+  <c-c>
+    退出CtrlP。
+
+移动:~
+
+  <c-j>,
+  <down>
+    向下移动。
+
+  <c-k>,
+  <up>
+    向上移动。
+
+  <c-a>
+    移动光标到提示符面板的 'start' 开头。
+
+  <c-e>
+    移动光标到提示符面板的 'end' 末尾。
+
+  <c-h>,
+  <left>,
+  <c-^>
+    向左 'left' 移动一个字符。
+
+  <c-l>,
+  <right>
+    向右 'right' 移动一个字符。
+
+编辑:~
+
+  <c-]>,
+  <bs>
+    删除前一个字符。
+
+  <del>
+    删除当前字符。
+
+  <c-w>
+    删除前一个单词。
+
+  <c-u>
+    清除输入。
+
+浏览输入历史:~
+
+  <c-n>
+    提示符面板历史里的下一个字符串。
+
+  <c-p>
+    提示符面板历史里的上一个字符串。
+
+打开/创建文件:~
+
+  <cr>
+    如果可能的话在 'current' 当前窗口打开选择的文件。
+
+  <c-t>
+    在 'tab' 新标签打开选择的文件。
+    Open the selected file in a new 'tab'.
+
+  <c-v>
+    在 'vertical' 竖直分割窗口打开选择的文件。
+
+  <c-x>,
+  <c-cr>,
+  <c-s>
+    在 'horizontal' 水平分割窗口打开选择的文件。
+
+  <c-y>
+    创建一个新文件和它的父目录。
+
+打开多个文件:~
+
+  <c-z>
+    - 标记/取消标记一个被 <c-o> 打开的文件。
+    - 标记/取消标记一个被 <c-y> 在它的目录被创建的文件。
+
+  <c-o>
+    - 打开被 <c-z> 标记的文件。
+    - 当没有文件被 <c-z> 标记时，使用下列选项打开一个终端对话框:
+
+      打开被选择的文件:
+        t - 在新标签页中打开。
+        v - 在一个竖直分割窗口中。
+        h - 在一个水平分割窗口中。
+        r - 在当前窗口中打开。
+        i - 在隐藏的缓冲区中。
+        x - （可选的）使用 |g:ctrlp_open_func| 中定义的函数。
+
+      其它选项 （未显示）:
+        a - 标记匹配窗口中的所有文件。
+        d - 改变CtrlP的工作目录到被选择的文件的目录并切换到文件搜索模式。
+
+功能按键绑定:~
+
+  <F5>
+    - 刷新匹配窗口并且清除当前目录的缓存。
+    - 从最近最多使用中移除被删除的文件。
+
+  <F7>
+    最近最多使用模式：
+    - 清除最近最多使用列表。
+    - 删除被 <c-z> 标记的最近最多使用条目。
+    缓冲区模式：
+    - 删除光标下的条目或者删除被 <c-z> 标记的多个条目。
+
+粘贴:~
+
+  <Insert>,                                                   *'ctrlp-pasting'*
+  <MiddleMouse>
+    将剪贴板中的文本粘贴到提示符窗口中。
+
+  <c-\>
+    打开一个终端对话框来粘贴 <cword>， <cfile>，搜索寄存器的文本，上一次可视
+    化模式的选择，剪贴板或者任何寄存器到提示符面板中。
+
+使用 |g:ctrlp_prompt_mappings| 选择你自己的绑定。
+
+----------------------------------------
+当焦点在匹配窗口中时（使用 <s-tab> 来切换）:~
+
+  a-z
+  0-9
+  ~^-=;`',.+!@#$%&_(){}[]
+    在匹配第一个字符的行中循环。
+
+===============================================================================
+输入格式                                                  *ctrlp-input-formats*
+
+提示符面板的输入格式:~
+
+a)  字符串。
+
+    例如: 'abc' 被内部理解为 'a[^a]\{-}b[^b]\{-}c'
+
+b)  在正则表达式模式，输入字符串被按照Vim的正则表达式模式 |pattern| 来对待，不
+    进行任何修改。
+
+    例如: 'abc\d*efg' 会被解读为 'abc\d*efg'。
+
+    如何启用正则表达式模式参见 |ctrlp-fullregexp| （按键绑定）和 
+    |g:ctrlp_regexp_search| （选项）。
+
+c)  字符串末尾使用一个冒号':'跟随一个Vim命令来在打开那个文件后执行该命令。如果
+    你需要使用':'的字面意思，使用反斜杠转义'\:'。但打开多个文件时，命令会在每
+    个打开文件上执行。
+
+    例如: 使用':45'跳转到第45行。
+
+          使用':/any\:string'跳转到'any:string'第一次出现的地方。
+
+          使用':+setf\ myfiletype|50'来设置文件类型为 'myfiletype'，然后跳转
+          到第50行。
+
+          使用':diffthis'当打开多个文件时在前四个文件上调用 |:diffthis| 。
+
+    参见: Vim的 |++opt| 和 |+cmd|.
+
+d)  提交两个点号 '..' 来进入上级目录。如果想进入向上多级目录，每多一级使用一个
+    额外的点号:
+>
+         输入         解释为
+         ..           ../
+         ...          ../../
+         ....         ../../../
+<
+    注意: 如果父目录很大并且没有被缓存，可能会很慢。
+
+    你可以使用'@cd path/'来改变CtrlP的工作目录为path/。使用'@cd %:h'来改变为当
+    前文件的目录。
+
+e)  类似的，提交'/'或者'\'来查找或者跳转到项目的根目录。
+
+    如果项目很大，使用版本控制系统的列出命令来寻找文件可能会加速初始化扫描。（
+    更多细节参见 |g:ctrlp_user_command| )。
+
+    注意: d) 和 e) 只在文件，目录和混合模式生效。
+
+f)  输入一个不存在的文件名并且按下 <c-y> 来创建文件。如果使用 <c-z> 标记了一个
+    文件，将会在被标记的文件的目录下创建这个新文件。
+
+    例如: 使用 'newdir/newfile.txt' 会创建一个名为'newdir'的目录和一个名为
+          'newfile.txt'的文件。
+
+          如果一个条目'some/old/dirs/oldfile.txt'被 <c-z> 标记，然后 'newdir'
+          和'newfile.txt'会在'some/old/dirs'下被创建。最终的路径会像下面这样
+          'some/old/dirs/newdir/newfile.txt'.
+
+    注意: 在Windows下使用 '\' 代替 '/' （如果 |'shellslash'| 选项没有设置）。
+
+g)  在文件名模式（使用 <c-d> 切换）下，你可以使用被逗号分隔的一个主要的模式和
+    一个改善的模式。两个模式在正则表达式模式下像（a）或（b）那样工作。
+
+h)  使用?打开帮助文件。
+
+===============================================================================
+扩展                                                         *ctrlp-extensions*
+
+扩展是可选的。把它的名字添加到变量g:ctrlp_extensions中来开启扩展: >
+  let g:ctrlp_extensions = ['tag', 'buffertag', 'quickfix', 'dir', 'rtscript',
+                          \ 'undo', 'line', 'changes', 'mixed', 'bookmarkdir']
+<
+扩展的名字在变量中出现的顺序会是在使用命令 <c-f>， <c-b> 切换时扩展在状态栏中出
+现的顺序。
+
+可用的扩展:~
+
+                                                                    *:CtrlPTag*
+  * 标记模式:~
+    - 名称: 'tag'
+    - 命令: ":CtrlPTag"
+    - 在一个生成的标记文件中搜索标签，跳转到标签定义。使用Vim的 |'tags'| 来指定
+      标签文件的位置和名称。
+      例如: set tags+=doc/tags
+
+                                                                 *:CtrlPBufTag*
+                                                              *:CtrlPBufTagAll*
+  * 缓冲区标签模式:~
+    - 名称: 'buffertag'
+    - 命令: ":CtrlPBufTag [缓冲区]"，
+                ":CtrlPBufTagAll"。
+    - 在当前缓冲区或者所有列出的缓冲区中搜索标签并且跳转到定义。需要
+      |exuberant_ctags| 或者兼容的程序。
+
+                                                               *:CtrlPQuickfix*
+  * 快速修复模式:~
+    - 名称: 'quickfix'
+    - 命令: ":CtrlPQuickfix"
+    - 在当前的快速修复错误列表中搜索条目并且跳转过去。
+
+                                                                    *:CtrlPDir*
+  * 目录模式:~
+    - 名称: 'dir'
+    - 命令: ":CtrlPDir [起始muu]"
+    - 搜索目录并且将其作为工作目录。
+    - 按键绑定:
+      + <cr> 为CtrlP修改工作目录并且保持打开状态。
+      + <c-t> 修改全局的工作目录（退出）。
+      + <c-v> 为当前窗口修改工作目录（退出）。
+      + <c-x> 修改全局工作目录为CtrlP的当前工作目录（退出）。
+
+                                                                    *:CtrlPRTS*
+  * 运行时脚本模式:~
+    - 名称: 'rtscript'
+    - 命令: ":CtrlPRTS"
+    - 在运行时路径中寻找文件（vimscripts, docs, snippets...）。
+
+                                                                   *:CtrlPUndo*
+  * 撤销模式:~
+    - 名称: 'undo'
+    - 命令: ":CtrlPUndo"
+    - 浏览撤销历史。
+
+                                                                   *:CtrlPLine*
+  * 行模式:~
+    - 名称: 'line'
+    - 命令: ":CtrlPLine [缓冲区]"
+    - 在所有列出的缓冲区或者在指定的 [buffer] 缓冲区内搜索一行内容。
+
+                                                                 *:CtrlPChange*
+                                                              *:CtrlPChangeAll*
+  * 修改列表模式:~
+    - 名称: 'changes'
+    - 命令: ":CtrlPChange [缓冲区]",
+            ":CtrlPChangeAll".
+    - 在当前缓冲区或者在所有列出的缓冲区内搜索最近的修改并跳转。
+
+                                                                  *:CtrlPMixed*
+  * 混合模式:~
+    - 名称: 'mixed'
+    - 命令: ":CtrlPMixed"
+    - 同时在文件，缓冲区和最近最多修改中搜索。
+
+                                                            *:CtrlPBookmarkDir*
+                                                         *:CtrlPBookmarkDirAdd*
+  * 书签目录模式:~
+    - 名称: 'bookmarkdir'
+    - 命令: ":CtrlPBookmarkDir",
+            ":CtrlPBookmarkDirAdd [目录] [标题]".
+            ":CtrlPBookmarkDirAdd! [目录] [标题]".
+    - 搜索一个被书签标记的目录并将其作为工作目录。
+    - 以指定的[标题]添加[目录]到 CtrlPBookmarkDir 中，如果没有给出[标题]或
+      者[目录]，会请求用户输入。
+    - 以指定的[标题]添加[目录]到 CtrlPBookmarkDir 中，如果没有给出目录，则
+      默认为当前目录( [CWD] )，如果没有给出[标题] ，会请求用户输入。
+
+      最新的用来添加所有最近使用过的目录到 CtrlPBookmarkDir 列表中的自动命令
+      如下
+      >
+      augroup CtrlPDirMRU
+        autocmd!
+        autocmd FileType * if &modifiable | execute 'silent CtrlPBookmarkDirAdd! %:p:h' | endif
+      augroup END
+<
+
+    - 按键绑定:
+      + <cr> 为CtrlP修改工作目录并且保持打开状态，并且切换到文件搜索模式。
+      + <c-x> 修改全局的工作目录（退出）。
+      + <c-v> 为当前窗口修改工作目录（退出）。
+      + <F7>
+        - 清除书签列表。
+        - 删除被 <c-z> 标记的书签条目。
+
+                                                 *ctrlp-autoignore-extension*
+  * 自动忽略模式:~
+    - 名称: 'autoignore'
+
+    - 这个扩展并不会添加新命令。它支持通过项目根目录中的 `.ctrlpignore` 文件为
+      每个项目设置忽略模式 (就像属于单个项目的 |ctrlp_custom_ignore|)。基本
+      上就像 CtrlP 的 `.gitignore` 或者 `.hgignore`。
+
+      注意: 当使用 |g:ctrlp_user_command| 自动忽略模式不起作用。
+
+      注意: `.ctrlpignore` 会被当做根目录的标识(参见 |g:ctrlp_root_markers|).
+
+    - 忽略文件的语法:
+      空行，以 `#` （注释）开头的行会被忽略。
+
+      其他行会被当做正则表达式。 匹配模式如何被使用参见 *string-match* 。
+      任意条目，只要匹配到任意匹配模式，就会从 CtrlP 中搜索结果中忽略。
+
+      例子:
+
+        \.tmp$
+        ^generated/
+        local\.cfg
+
+      注意: 即使在 Windows 上模式也应该使用反斜线。
+
+      你也可以像下面那样使用 glob 命令风格的语法：
+
+        syntax:wildignore
+        *.tar.gz
+        *.tmp
+
+      这样会在搜索文件时临时的把每一个匹配模式添加到 |'wildignore'|
+      中，结束时移除。
+
+      你也可以通过下面的方式切换回默认的正则表达式为基础的模式：
+
+        syntax:regexp
+
+      你也可以只为某一条目类型（文件、目录...）设置匹配模式：
+
+        dir:build
+        file:foo\.txt
+
+      这样只会忽略包含 "build" 的目录和包含 "foo.txt" 的文件。不会忽略带
+      有 "build" 的文件或者反过来。
+
+      注意: 如果为了忽略名为 "build" 的目录，而不是『任何』包含 "build" 
+      的目录，你可以使用下面的正则： ^build$
+
+    - 常见问题:
+      问: 为什么 CtrlP 不能直接支持原生的 `.gitignore` or `.hgignore` ?
+
+      答: 这些文件初看起来好像已经包含了所有你想从 CtrlP 中排除的文件。但是
+      通常情况下，这些文件和你想在 CtrlP 中的配置会有一些不同。这些配置文件
+      列出了不能被包含到版本控制中的文件。这些不能被包含到版本控制中的文件
+      包括了你想忽略的，但是同时可能也包含了你不想忽略的：本地设置，外部包
+      和依赖，等等。作者觉得支持多种语法与只是简单的复制/粘贴几行忽略规则比
+      起来比较麻烦。如果你不这么觉得可以随时提交补丁 :)
+
+      问: 我开启了 |ctrlp-autoignore-extension|， 或者编辑了 `.ctrlpignore`
+      但是这些新模式并没有起作用。我哪里做错了？
+
+      答: 可能什么都没做错！CtrlP 可以为了快速的响应缓存搜索结果。你可以按
+      <F5> 强制刷新。如果 `.ctrlpignore` 改动过，这样也会使用新的匹配模式。
+
+----------------------------------------
+缓冲标签模式选项:~
+
+                                                   *'g:ctrlp_buftag_ctags_bin'*
+如果ctags没有在环境变量中配置，使用该选项来指定它的位置: >
+  let g:ctrlp_buftag_ctags_bin = ''
+<
+
+                                                   *'g:ctrlp_buftag_systemenc'*
+将该选项与你的操作系统的编码（非Vim的）保持一致。默认值使用Vim的全局
+|'encoding'| 选项: >
+  let g:ctrlp_buftag_systemenc = &encoding
+<
+
+                                                       *'g:ctrlp_buftag_types'*
+使用该选项来在ctags, jsctags...中为指定的文件格式设置参数: >
+  let g:ctrlp_buftag_types = ''
+<
+例子: >
+  let g:ctrlp_buftag_types = {
+    \ 'erlang'     : '--language-force=erlang --erlang-types=drmf',
+    \ 'javascript' : {
+      \ 'bin': 'jsctags',
+      \ 'args': '-f -',
+      \ },
+    \ }
+<
+
+===============================================================================
+自定义                                                    *ctrlp-customization*
+
+高亮:~
+  * CtrlP缓冲区的设置:
+    CtrlPNoEntries : 当没有匹配被发现时的消息（错误）。
+    CtrlPMatch     : 匹配模式（标识）。
+    CtrlPLinePre   : 匹配窗口的行前缀'>'。
+    CtrlPPrtBase   : 提示符窗口的基础（注释）。
+    CtrlPPrtText   : 提示符窗口的文本 （|hl-Normal|）。
+    CtrlPPrtCursor : 提示符窗口的光标在文本上移动时（常量）。
+
+  * 缓冲区浏览模式:
+    CtrlPBufferNr     : 缓冲区编号
+    CtrlPBufferInd    : '+', '-', '=' 和 '#' 指示符 (参见 |:buffers|)
+    CtrlPBufferHid    : 隐藏缓冲区
+    CtrlPBufferHidMod : 隐藏和被编辑过的缓冲区
+    CtrlPBufferVis    : 可见的缓冲区
+    CtrlPBufferVisMod : 可见的和被编辑过的缓冲区
+    CtrlPBufferCur    : 当前缓冲区
+    CtrlPBufferCurMod : 当前和被编辑过的缓冲区
+    CtrlPBufferPath   : 缓冲区路径
+
+  * 在扩展中:
+    CtrlPTabExtra  : 每一行中不匹配的部分（注释）。
+    CtrlPBufName   : 条目所属的缓冲区名称（|hl-Directory|）。
+    CtrlPTagKind   : 缓冲区标签模式中标签的类型（|hl-Title|）。
+    CtrlPqfLineCol : 快速修复模式中行和列的序号（注释）。
+    CtrlPUndoT     : 撤销模式的流逝时间（|hl-Directory|）。
+    CtrlPUndoBr    : 撤销模式的方括号（注释）。
+    CtrlPUndoNr    : 撤销模式的方括号中的数字（字符串）。
+    CtrlPUndoSv    : 文件被保存的点（注释）。
+    CtrlPUndoPo    : 撤销树中的当前位置（|hl-Title|）。
+    CtrlPBookmark  : 书签的名称（标识）。
+
+状态栏:~
+  * 高亮组:
+    CtrlPMode1 : 'file' 或 'path' 或 'line'，和当前模式（字符）。
+    CtrlPMode2 : 'prt' 或 'win'， 'regex'，工作目录 |hl-LineNr| 。
+    CtrlPStats : 扫描状态（函数）。
+
+  重新构建状态栏，参见 |g:ctrlp_status_func| 。
+
+===============================================================================
+其它选项                                          *ctrlp-miscellaneous-configs*
+
+* 为 |g:ctrlp_user_command| 使用 |wildignore| :
+>
+  function! s:wig2cmd()
+    " 修改wildignore为空格或者|分隔的组
+    " 例如: .aux .out .toc .jpg .bmp .gif
+    " 或者  .aux$\|.out$\|.toc$\|.jpg$\|.bmp$\|.gif$
+    let pats = ['[*\/]*\([?_.0-9A-Za-z]\+\)\([*\/]*\)\(\\\@<!,\|$\)','\\\@<!,']
+    let subs = has('win32') || has('win64') ? ['\1\3', ' '] : ['\1\2\3', '\\|']
+    let expr = substitute(&wig, pats[0], subs[0], 'g')
+    let expr = substitute(expr, pats[1], subs[1], 'g')
+    let expr = substitute(expr, '\\,', ',', 'g')
+
+    " 设置用户命令选项
+    let g:ctrlp_user_command = has('win32') || has('win64')
+      \ ? 'dir %s /-n /b /s /a-d | findstr /V /l "'.expr.'"'
+      \ : 'find %s -type f | grep -v "'.expr .'"'
+  endfunction
+
+  call s:wig2cmd()
+<
+（由 Rich Alesi <github.com/ralesi> 提交）
+
+* 一个独立的函数，设置项目的根目录为工作目录，如果没有找到根目录的话使用当前文
+* 件的父目录。
+>
+  function! s:setcwd()
+    let cph = expand('%:p:h', 1)
+    if cph =~ '^.\+://' | retu | en
+    for mkr in ['.git/', '.hg/', '.svn/', '.bzr/', '_darcs/', '.vimprojects']
+      let wd = call('find'.(mkr =~ '/$' ? 'dir' : 'file'), [mkr, cph.';'])
+      if wd != '' | let &acd = 0 | brea | en
+    endfo
+    exe 'lc!' fnameescape(wd == '' ? cph : substitute(wd, mkr.'$', '.', ''))
+  endfunction
+
+  autocmd BufEnter * call s:setcwd()
+<
+(需要 Vim 7.1.299+)
+
+* 使用 |count| 来使用同样的按键绑定调用不同的命令:
+>
+  let g:ctrlp_cmd = 'exe "CtrlP".get(["", "Buffer", "MRU"], v:count)'
+<
+
+===============================================================================
+开发人员                                                        *ctrlp-credits*
+
+最初由 Kien Nguyen <github.com/kien>开发。现在由 Github 上 ctrlpvim 组织的成员
+维护(https://github.com/orgs/ctrlpvim/people) 。在Vim的 |license| 下发行。
+
+项目主页:   http://ctrlpvim.github.com/ctrlp.vim
+Git 仓库:   https://github.com/ctrlpvim/ctrlp.vim
+
+-------------------------------------------------------------------------------
+感谢所有通过github，bitbucket或电子邮件提供想法，报告bug或者帮助debugging的人。
+
+特别感谢:~
+
+    * Woojong Koh <github.com/wjkoh>
+    * Simon Ruderich
+    * Yasuhiro Matsumoto <github.com/mattn>
+    * Ken Earley <github.com/kenearley>
+    * Kyo Nagashima <github.com/hail2u>
+    * Zak Johnson <github.com/zakj>
+    * Diego Viola <github.com/diegoviola>
+    * Piet Delport <github.com/pjdelport>
+    * Thibault Duplessis <github.com/ornicar>
+    * Kent Sibilev <github.com/datanoise>
+    * Tacahiroy <github.com/tacahiroy>
+    * Luca Pette <github.com/lucapette>
+    * Seth Fowler <github.com/sfowler>
+    * Lowe Thiderman <github.com/thiderman>
+    * Christopher Fredén <github.com/icetan>
+    * Zahary Karadjov <github.com/zah>
+    * Jo De Boeck <github.com/grimpy>
+    * Rudi Grinberg <github.com/rgrinberg>
+    * Timothy Mellor <github.com/mellort>
+    * Sergey Vlasov <github.com/noscript>
+
+===============================================================================
+更新日志                                                      *ctrlp-changelog*
+
+    + 新的支持高亮的缓冲区浏览模式 (建议 |+conceal|)
+    + 新选项: |g:ctrlp_bufname_mod|,
+              |g:ctrlp_bufpath_mod|
+    + 结合 *g:ctrlp_match_window_bottom* *g:ctrlp_match_window_reversed* 和
+      *g:ctrlp_max_height* 到 |g:ctrlp_match_window| 。
+    + 新选项: |g:ctrlp_match_window| 。
+
+在2012/11/30之前~
+
+    + 新选项: |g:ctrlp_abbrev|，
+              |g:ctrlp_key_loop|，
+              |g:ctrlp_open_func|，
+              |g:ctrlp_tabpage_position|，
+              |g:ctrlp_mruf_save_on_update|
+    + 重命名:
+        *g:ctrlp_dotfiles* -> |g:ctrlp_show_hidden| 。
+    + 修改 |g:ctrlp_switch_buffer| 和 |g:ctrlp_working_path_mode|的类型
+      （旧值仍然工作）。
+    + 当 |g:ctrlp_user_command| 是一个字典时，为其增加一个新的键: 'ignore'。
+
+在2012/06/15之前~
+
+    + |g:ctrlp_follow_symlinks| 的新值: 2。
+    + |g:ctrlp_open_multiple_files| 的新值: 'j'。
+    + 允许使用 <c-t>, <c-x>, <c-v> 打开被 <c-z> 标记的文件。
+    + 扩展 '..' (|ctrlp-input-formats| (d))
+    + 新的输入格式: '@cd' (|ctrlp-input-formats| (d))
+
+在2012/04/30之前~
+
+    + 新选项: |g:ctrlp_mruf_default_order|
+    + 新特性: 被书签标记的目录的扩展。
+    + 新命令: |:CtrlPBookmarkDir|
+              |:CtrlPBookmarkDirAdd|
+
+在2012/04/15之前~
+
+    + 新选项: |g:ctrlp_buffer_func|，CtrlP缓冲区的回调函数。
+    + 移除  : g:ctrlp_mruf_last_entered，使其作为最近最多使用的默认行为。
+    + 新命令: |:CtrlPLastMode|，以上一次使用的模式打开CtrlP。
+              |:CtrlPMixed|，在文件，缓冲区和最近最多使用中搜索。
+
+在2012/03/31之前~
+
+    + 新选项: |g:ctrlp_default_input|， 进入CtrlP后的默认输入。
+              |g:ctrlp_match_func|，允许使用自定义的模糊查找工具。
+    + 重命名:
+        *ClearCtrlPCache* -> |CtrlPClearCache|
+        *ClearAllCtrlPCaches* -> |CtrlPClearAllCaches|
+        *ResetCtrlP* -> |CtrlPReload|
+
+在2012/03/02之前~
+
+    + 重命名:
+        *g:ctrlp_regexp_search* -> |g:ctrlp_regexp|，
+        *g:ctrlp_dont_split* -> |g:ctrlp_reuse_window|，
+        *g:ctrlp_jump_to_buffer* -> |g:ctrlp_switch_buffer|。
+    + 重命名和微调:
+        *g:ctrlp_open_multi* -> |g:ctrlp_open_multiple_files|。
+    + 过时 *g:ctrlp_highlight_match*
+    + 扩展 |g:ctrlp_user_command| 支持多个命令。
+    + 新选项: |g:ctrlp_mruf_last_entered| 修改最近最多使用为最近进入。
+
+在2012/01/15之前~
+
+    + 新按键绑定: 交换 <tab> 和 <s-tab>. <tab> 现在用来补全在当前工作目录内的目
+                  录名。
+    + 新选项: |g:ctrlp_arg_map| 使 <c-y>， <c-o> 可以接收一个参数。
+              |g:ctrlp_status_func| 自定义状态栏。
+              |g:ctrlp_mruf_relative| 在当前工作目录内显示最近最多使用。
+    + 扩展 g:ctrlp_open_multi 增加新选项值： tr， hr， vr。
+    + 扩展 |g:ctrlp_custom_ignore| 指定过滤目录，文件和链接。
+
+在2012/01/05之前~
+
+    + 新特性: 缓冲区标记扩展。
+    + 新命令: |:CtrlPBufTag|, |:CtrlPBufTagAll|。
+    + 新选项: |g:ctrlp_cmd|，
+              |g:ctrlp_custom_ignore|
+
+在2011/11/30之前~
+
+    + 新特性: 标签，快速修复和目录扩展。
+    + 新命令: |:CtrlPTag|, |:CtrlPQuickfix|, |:CtrlPDir|。
+    + 新选项: |g:ctrlp_use_migemo|，
+              |g:ctrlp_lazy_update|，
+              |g:ctrlp_follow_symlinks|
+
+在2011/11/13之前~
+
+    + 新的特殊输入: '/' 和 '\' 查找根目录 (|ctrlp-input-formats| (e))
+    + 移除 ctrlp#SetWorkingPath()。
+    + 移除 *g:ctrlp_mru_files* ，使最近最多使用模式变为永久的。
+    + 扩展 g:ctrlp_open_multi，添加打开文件的新方式。
+    + 新选项: g:ctrlp_dont_split，
+              |g:ctrlp_mruf_case_sensitive|
+
+在2011/10/30之前~
+
+    + 新特性: 支持自定义扩展。
+              <F5> 也会从最近最多使用列表中移除不存在的文件。
+    + 新选项: g:ctrlp_jump_to_buffer
+
+在2011/10/12之前~
+
+    + 新特性: 打开多个文件。
+              传递Vim的 |++opt| 和 |+cmd| 到新打开的文件
+              (|ctrlp-input-formats| (c))
+              为 |:CtrlP| [起始目录]自动补全每个目录
+    + 新按键绑定: <c-z> 标记/取消标记一个被 <c-o> 打开的文件。
+                  <c-o> 打开所有被标记的文件。
+    + 新选项: g:ctrlp_open_multi
+    + 移除 *g:ctrlp_persistent_input* *g:ctrlp_live_update* and <c-^>。
+
+在2011/09/29之前~
+
+    + 新按键绑定: <c-n>, <c-p> 输入历史中的前一个/后一个字符串。
+                  <c-y> 创建一个新的文件和它的父目录。
+    + 新选项: |g:ctrlp_open_new_file|，
+                   |g:ctrlp_max_history|
+    + 添加一个新的在横向分割窗口打开的绑定：<c-x>
+
+在2011/09/19之前~
+
+    + 新命令: ResetCtrlP
+    + 新选项: |g:ctrlp_max_files|，
+              |g:ctrlp_max_depth|，
+              g:ctrlp_live_update
+    + 新按键绑定: <c-^>
+
+在2011/09/12之前~
+
+    + 添加在匹配窗口内循环匹配行的功能。
+    + 扩展 g:ctrlp_persistent_input的行为
+    + 扩展 |:CtrlP| 的行为
+    + 新选项: |g:ctrlp_dotfiles|，
+              |g:ctrlp_clear_cache_on_exit|，
+              g:ctrlp_highlight_match，
+              |g:ctrlp_user_command|
+    + 新的特殊输入: '..' (|ctrlp-input-formats| (d))
+    + 新按键绑定: <F5>。
+    + 新命令: |:CtrlPCurWD|，
+              |:CtrlPCurFile|，
+              |:CtrlPRoot|
+
+    + 新特性: 在最近最常使用的文件列表中搜索
+    + 新按键绑定: <c-b>。
+    + 扩展 <c-f> 的行为。
+    + 新选项: g:ctrlp_mru_files，
+              |g:ctrlp_mruf_max|，
+              |g:ctrlp_mruf_exclude|，
+              |g:ctrlp_mruf_include|
+    + 新命令: |:CtrlPMRU|
+
+第一版发布于: 2011/09/06~
+
+===============================================================================
+vim:ft=help:et:ts=2:sw=2:sts=2:norl

--- a/sources_non_forked/ctrlp.vim/doc/ctrlp.txt
+++ b/sources_non_forked/ctrlp.vim/doc/ctrlp.txt
@@ -63,17 +63,25 @@ Overview:~
   |ctrlp_default_input|.........Seed the prompt with an initial string.
   |ctrlp_abbrev|................Input abbreviations.
   |ctrlp_key_loop|..............Use input looping for multi-byte input.
-  |ctrlp_use_migemo|............Use Migemo patterns for Japanese filenames.
   |ctrlp_prompt_mappings|.......Change the mappings inside the prompt.
+  |ctrlp_line_prefix|...........Prefix for each line in ctrlp window.
+  |ctrlp_open_single_match|.....Automatically accept when only one candidate.
+  |ctrlp_brief_prompt|..........Exit CtrlP on empty prompt by <bs>.
+  |ctrlp_match_current_file|....Include current file in match entries.
 
   MRU mode:
   |ctrlp_mruf_max|..............Max MRU entries to remember.
   |ctrlp_mruf_exclude|..........Files that shouldn't be remembered.
   |ctrlp_mruf_include|..........Files to be remembered.
   |ctrlp_mruf_relative|.........Show only MRU files in the working directory.
+  |ctrlp_tilde_homedir|....Save MRU file paths in home dir as ~/.
   |ctrlp_mruf_default_order|....Disable sorting.
   |ctrlp_mruf_case_sensitive|...MRU files are case sensitive or not.
   |ctrlp_mruf_save_on_update|...Save to disk whenever a new entry is added.
+
+  Buffer mode:
+  |ctrlp_bufname_mod|...........File name section modificator.
+  |ctrlp_bufpath_mod|...........File path section modificator.
 
   BufferTag mode: (to enable, see |ctrlp-extensions|)
   |g:ctrlp_buftag_ctags_bin|....The location of the ctags-compatible binary.
@@ -118,7 +126,7 @@ Set this to 1 to set regexp search as the default: >
 Can be toggled on/off by pressing <c-r> inside the prompt.
 
                                                        *'g:ctrlp_match_window'*
-Change the postion, the listing order of results, the minimum and the maximum
+Change the position, the listing order of results, the minimum and the maximum
 heights of the match window: >
   let g:ctrlp_match_window = ''
 <
@@ -181,13 +189,12 @@ variable: >
   let g:ctrlp_working_path_mode = 'ra'
 <
   c - the directory of the current file.
-  a - like "c", but only applies when the current working directory outside of
-      CtrlP isn't a direct ancestor of the directory of the current file.
-  r - the nearest ancestor that contains one of these directories or files:
+  a - the directory of the current file, unless it is a subdirectory of the cwd
+  r - the nearest ancestor of the current file that contains one of these
+      directories or files:
       .git .hg .svn .bzr _darcs
-  w - begin finding a root from the current working directory outside of CtrlP
-      instead of from the directory of the current file (default). Only applies
-      when "r" is also present.
+  w - modifier to "r": start search from the cwd instead of the current file's
+      directory
   0 or <empty> - disable this feature.
 
 Note #1: if "a" or "c" is included with "r", use the behavior of "a" or "c" (as
@@ -261,6 +268,9 @@ Examples: >
   let g:ctrlp_custom_ignore = {
     \ 'file': '\v(\.cpp|\.h|\.hh|\.cxx)@<!$'
     \ }
+  let g:ctrlp_custom_ignore = {
+    \ 'func': 'some#custom#match_function'
+    \ }
 <
 Note #1: by default, |wildignore| and |g:ctrlp_custom_ignore| only apply when
 |globpath()| is used to scan for files, thus these options do not apply when a
@@ -268,6 +278,12 @@ command defined with |g:ctrlp_user_command| is being used.
 
 Note #2: when changing the option's variable type, remember to |:unlet| it
 first or restart Vim to avoid the "E706: Variable type mismatch" error.
+
+Note #3: when using the "func" ignore type, you must provide the full name of
+a function that can be called from CtrlP. An |autoload| function name is
+recommended here. The function must take 2 parameters, the item to match and
+its type. The type will be "dir", "file", or "link". The function must return
+1 if the item should be ignored, 0 otherwise.
 
                                                           *'g:ctrlp_max_files'*
 The maximum number of files to scan, set to 0 for no limit: >
@@ -327,7 +343,7 @@ Some examples: >
 
   " Single VCS, listing command lists untracked files (slower):
   let g:ctrlp_user_command =
-    \ ['.git', 'cd %s && git ls-files . -co --exclude-standard']
+    \ ['.git', 'cd %s && git ls-files -co --exclude-standard']
 
   let g:ctrlp_user_command =
     \ ['.hg', 'hg --cwd %s status -numac -I . $(hg root)'] " MacOSX/Linux
@@ -434,6 +450,17 @@ Instead of 1 or 0, if the value of the option is a string, it'll be used as-is
 as the default input: >
   let g:ctrlp_default_input = 'anystring'
 <
+This option works well together with |g:ctrlp_open_single_match|
+
+
+                                                 *'g:ctrlp_match_current_file'*
+Includes the current file in the match entries:
+  let g:ctrlp_match_current_file = 1
+
+By default, the current file is excluded from the list.
+
+Note: does not apply when |g:ctrlp_match_func| is used. 
+
 
                                                              *'g:ctrlp_abbrev'*
 Define input abbreviations that can be expanded (either internally or visibly)
@@ -497,12 +524,6 @@ Note #2: you can toggle this feature inside the prompt with a custom mapping: >
   let g:ctrlp_prompt_mappings = { 'ToggleKeyLoop()': ['<F3>'] }
 <
 
-                                                         *'g:ctrlp_use_migemo'*
-Set this to 1 to use Migemo Pattern for Japanese filenames. Migemo Search only
-works in regexp mode. To split the pattern, separate words with space: >
-  let g:ctrlp_use_migemo = 0
-<
-
                                                     *'g:ctrlp_prompt_mappings'*
 Use this to customize the mappings inside CtrlP's prompt to your liking. You
 only need to keep the lines that you've changed the values (inside []): >
@@ -549,6 +570,34 @@ default <c-h> mapping: >
   let g:ctrlp_prompt_mappings = { 'PrtCurLeft()': ['<left>', '<c-^>'] }
 <
 
+                                                    *'g:ctrlp_line_prefix'*
+This prefix will be prepended to each line in ctrlp's item listing.
+default: >
+  let g:ctrlp_line_prefix = '> '
+<
+
+                                                    *'g:ctrlp_open_single_match'*
+List of CtrlP modes for which CtrlP should accept an entry directly, if only
+one candidate exists.
+Example: >
+  let g:ctrlp_open_single_match = ['buffer tags', 'buffer']
+<
+This is currently only really useful together with |g:ctrlp_default_input|
+set before launching, and cleared afterwards, with a function such as
+following: >
+  fu! <SID>tagsUnderCursor()
+    try
+      let default_input_save = get(g:, 'ctrlp_default_input', '')
+      let g:ctrlp_default_input = expand('<cword>')
+      CtrlPBufTagAll
+    finally
+      if exists('default_input_save')
+        let g:ctrlp_default_input = default_input_save
+      endif
+    endtry
+  endfu
+>
+<
 ----------------------------------------
 MRU mode options:~
 
@@ -574,6 +623,14 @@ Example: >
   let g:ctrlp_mruf_include = '\.py$\|\.rb$'
 <
 
+                                                 *'g:ctrlp_tilde_homedir'*
+Set this to 1 to save every MRU file path $HOME/$filepath in the $HOME dir
+  as ~/$filepath instead of $HOME/$filepath : >
+  let g:ctrlp_tilde_homedir = 0
+<
+Note: This applies also to all dir paths stored by :CtrlPBookmarkDirAdd!
+<
+
                                                       *'g:ctrlp_mruf_relative'*
 Set this to 1 to show only MRU files in the current working directory: >
   let g:ctrlp_mruf_relative = 0
@@ -581,7 +638,6 @@ Set this to 1 to show only MRU files in the current working directory: >
 Note: you can use a custom mapping to toggle this option inside the prompt: >
   let g:ctrlp_prompt_mappings = { 'ToggleMRURelative()': ['<F2>'] }
 <
-
                                                  *'g:ctrlp_mruf_default_order'*
 Set this to 1 to disable sorting when searching in MRU mode: >
   let g:ctrlp_mruf_default_order = 0
@@ -598,7 +654,14 @@ Set this to 0 to disable saving of the MRU list to hard drive whenever a new
 entry is added, saving will then only occur when exiting Vim: >
   let g:ctrlp_mruf_save_on_update = 1
 <
-
+                                                *'g:ctrlp_bufname_mod'*
+Modify file name section according to modificator string. See |filename-modifiers|. >
+  let g:ctrlp_bufname_mod = ':t'
+<
+                                                *'g:ctrlp_bufpath_mod'*
+Modify file path section according to modificator string. See |filename-modifiers|. >
+  let g:ctrlp_bufpath_mod = ':~:.:h'
+<
 ----------------------------------------
 Advanced options:~
 
@@ -772,6 +835,15 @@ Example: >
     " }
   endfunction
 <
+                                                       *'g:ctrlp_brief_prompt'*
+When this is set to 1, the <bs> on empty prompt exit CtrlP.
+
+                                                          *ctrlp-default-value*
+Otherwize, you can use below to change default value.
+Example: >
+  let g:ctrlp_path_nolim = 1
+
+This is possible to change no-limit mode for match type "path".
 
 ===============================================================================
 COMMANDS                                                       *ctrlp-commands*
@@ -953,8 +1025,12 @@ Function keys:~
     - Remove deleted files from the MRU list.
 
   <F7>
-    - Wipe the MRU list.
-    - Delete MRU entries marked by <c-z>.
+    MRU mode:
+    - Wipe the list.
+    - Delete entries marked by <c-z>.
+    Buffer mode:
+    - Delete entry under the cursor or delete multiple entries marked by <c-z>.
+
 
 Pasting:~
 
@@ -1027,7 +1103,7 @@ d)  Submit two dots '..' to go upward the directory tree by 1 level. To go up
 e)  Similarly, submit '/' or '\' to find and go to the project's root.
 
     If the project is large, using a VCS listing command to look for files
-    might help speeding up the intial scan (see |g:ctrlp_user_command| for more
+    might help speeding up the initial scan (see |g:ctrlp_user_command| for more
     details).
 
     Note: d) and e) only work in file, directory and mixed modes.
@@ -1138,8 +1214,27 @@ Available extensions:~
   * BookmarkDir mode:~
     - Name: 'bookmarkdir'
     - Commands: ":CtrlPBookmarkDir",
-                ":CtrlPBookmarkDirAdd [directory]".
+                ":CtrlPBookmarkDirAdd  [directory] [TITLE]".
+                ":CtrlPBookmarkDirAdd! [directory] [TITLE]".
+
     - Search for a bookmarked directory and change the working directory to it.
+    - Add either the dir [directory], if supplied, or otherwise ask for it,
+      under the title given by either [TITLE], if supplied, or otherwise ask for
+      it, to the CtrlPBookmarkDir list.
+    - Add either the dir [directory], if supplied, or otherwise the current
+      work dir ( [CWD] ) under the title given by either [TITLE], if supplied,
+      or otherwise [CWD] to the CtrlPBookmarkDir list.
+
+    The last command can be used to add all recently used work dirs to the
+    CtrlPBookmarkDir list by an autocommand like
+
+    >
+    augroup CtrlPDirMRU
+      autocmd!
+      autocmd FileType * if &modifiable | execute 'silent CtrlPBookmarkDirAdd! %:p:h' | endif
+    augroup END
+<
+
     - Mappings:
       + <cr> change the local working directory for CtrlP, keep it open and
         switch to find file mode.
@@ -1148,6 +1243,80 @@ Available extensions:~
       + <F7>
         - Wipe bookmark list.
         - Delete entries marked by <c-z>.
+
+                                                 *ctrlp-autoignore-extension*
+  * Autoignore mode:~
+    - Name: 'autoignore'
+
+    - This extension doesn't add new commands. It adds support for per-project
+      ignore patterns (as per |ctrlp_custom_ignore|) via a `.ctrlpignore` file
+      at the root of the project. It's basically like a `.gitignore` or
+      `.hgignore` for CtrlP.
+
+      Note: auto-ignore won't work when |g:ctrlp_user_command| is used.
+
+      Note: `.ctrlpignore` will be added to the root markers (see
+      |g:ctrlp_root_markers|).
+
+    - Ignore file syntax:
+      Empty lines, and lines starting with `#` (comments) are ignored.
+
+      Other lines are treated like regular expression patterns. See *string-match*
+      for how patterns are used. Anything that matches any of the patterns will be
+      ignored from CtrlP's search results.
+
+      Example:
+
+        \.tmp$
+        ^generated/
+        local\.cfg
+
+      Note: patterns should use forward slashes, even on Windows.
+
+      You can also switch to a glob-like syntax like this:
+
+        syntax:wildignore
+        *.tar.gz
+        *.tmp
+
+      This will temporarily add each pattern to |'wildignore'| for the
+      duration of the file scan, and remove them at the end.
+
+      You can switch back to the default regular-expression-based patterns by
+      writing:
+
+        syntax:regexp
+
+      You can also specify a match on only a given type of item:
+
+        dir:build
+        file:foo\.txt
+
+      This will only ignore directories with "build" in them, and files with
+      "foo.txt" in them. Not files with "build" in them or vice-versa.
+
+      Note: to ignore a root directory "build", and not _any_ directory with
+      "build" in it, you can root the regex: ^build$
+
+    - FAQ:
+      Q: Why can't CtrlP support `.gitignore` or `.hgignore` natively?
+
+      A: Those files look at first like they may contain all the patterns
+      you'd want to exclude from CtrlP already. However, more often than not,
+      there are some differences. Those files list patterns that should not be
+      included in source-control. This includes things you want to ignore, but
+      also things you may not want to: local settings, external packages and
+      dependencies, etc. The author felt the trouble of supporting various
+      syntaxes was too much compared to just copy/pasting a few lines. Feel
+      free to contribute a patch if you disagree :)
+
+      Q: I enabled |ctrlp-autoignore-extension|, or edited `.ctrlpignore`, but
+      none of the new patterns are working. What did I do wrong?
+
+      A: Probably nothing! CtrlP can cache search results for faster response
+      times. You can hit <F5> to force it to refresh. This will use the newer
+      ignore patterns if the `.ctrlpignore` file has changed, too.
+
 
 ----------------------------------------
 Buffer Tag mode options:~
@@ -1188,6 +1357,17 @@ Highlighting:~
     CtrlPPrtBase   : the prompt's base (Comment)
     CtrlPPrtText   : the prompt's text (|hl-Normal|)
     CtrlPPrtCursor : the prompt's cursor when moving over the text (Constant)
+
+  * Buffer explorer mode:
+    CtrlPBufferNr     : buffer number
+    CtrlPBufferInd    : '+', '-', '=' and '#' indicators (see |:buffers|)
+    CtrlPBufferHid    : hidden buffer
+    CtrlPBufferHidMod : hidden and modified buffer
+    CtrlPBufferVis    : visible buffer
+    CtrlPBufferVisMod : visible and modified buffer
+    CtrlPBufferCur    : current buffer
+    CtrlPBufferCurMod : current and modified buffer
+    CtrlPBufferPath   : buffer path
 
   * In extensions:
     CtrlPTabExtra  : the part of each line that's not matched against (Comment)
@@ -1259,11 +1439,12 @@ MISCELLANEOUS CONFIGS                             *ctrlp-miscellaneous-configs*
 ===============================================================================
 CREDITS                                                         *ctrlp-credits*
 
-Developed by Kien Nguyen <github.com/kien>. Distributed under Vim's |license|.
+Originally developed by Kien Nguyen <github.com/kien>.  Now maintained by the
+members of the ctrlpvim Github organisation
+(https://github.com/orgs/ctrlpvim/people).  Distributed under Vim's |license|.
 
-Project's homepage:   http://kien.github.com/ctrlp.vim
-Git repository:       https://github.com/kien/ctrlp.vim
-Mercurial repository: https://bitbucket.org/kien/ctrlp.vim
+Project's homepage:   http://ctrlpvim.github.com/ctrlp.vim
+Git repository:       https://github.com/ctrlpvim/ctrlp.vim
 
 -------------------------------------------------------------------------------
 Thanks to everyone that has submitted ideas, bug reports or helped debugging on
@@ -1290,10 +1471,14 @@ Special thanks:~
     * Jo De Boeck <github.com/grimpy>
     * Rudi Grinberg <github.com/rgrinberg>
     * Timothy Mellor <github.com/mellort>
+    * Sergey Vlasov <github.com/noscript>
 
 ===============================================================================
 CHANGELOG                                                     *ctrlp-changelog*
 
+    + New buffer explorer mode with highlighting (|+conceal| recommended)
+    + New options: |g:ctrlp_bufname_mod|,
+                   |g:ctrlp_bufpath_mod|
     + Combine *g:ctrlp_match_window_bottom* *g:ctrlp_match_window_reversed* and
       *g:ctrlp_max_height* into |g:ctrlp_match_window|.
     + New option: |g:ctrlp_match_window|.

--- a/sources_non_forked/ctrlp.vim/plugin/ctrlp.vim
+++ b/sources_non_forked/ctrlp.vim/plugin/ctrlp.vim
@@ -33,8 +33,10 @@ com! -bar CtrlPCurWD   cal ctrlp#init(0, { 'mode': '' })
 com! -bar CtrlPCurFile cal ctrlp#init(0, { 'mode': 'c' })
 com! -bar CtrlPRoot    cal ctrlp#init(0, { 'mode': 'r' })
 
-if g:ctrlp_map != '' && !hasmapto(':<c-u>'.g:ctrlp_cmd.'<cr>', 'n')
-	exe 'nn <silent>' g:ctrlp_map ':<c-u>'.g:ctrlp_cmd.'<cr>'
+exe 'nn <silent> <plug>(ctrlp) :<c-u>'.g:ctrlp_cmd.'<cr>'
+
+if g:ctrlp_map != '' && !hasmapto('<plug>(ctrlp)')
+	exe 'map' g:ctrlp_map '<plug>(ctrlp)'
 en
 
 cal ctrlp#mrufiles#init()
@@ -62,7 +64,7 @@ com! -bar CtrlPChangeAll   cal ctrlp#init(ctrlp#changes#cmd(1))
 com! -bar CtrlPMixed       cal ctrlp#init(ctrlp#mixed#id())
 com! -bar CtrlPBookmarkDir cal ctrlp#init(ctrlp#bookmarkdir#id())
 
-com! -n=? -com=dir CtrlPBookmarkDirAdd
-	\ cal ctrlp#call('ctrlp#bookmarkdir#add', <q-args>)
+com! -n=? -com=dir -bang CtrlPBookmarkDirAdd
+	\ cal ctrlp#call('ctrlp#bookmarkdir#add', '<bang>', <q-args>)
 
 " vim:ts=2:sw=2:sts=2

--- a/sources_non_forked/ctrlp.vim/readme.md
+++ b/sources_non_forked/ctrlp.vim/readme.md
@@ -1,6 +1,3 @@
-#**This project is unmaintained** 
-**You should use [this fork](https://github.com/ctrlpvim/ctrlp.vim) instead.**
-
 # ctrlp.vim
 Full path fuzzy __file__, __buffer__, __mru__, __tag__, __...__ finder for Vim.
 
@@ -35,8 +32,8 @@ Check `:help ctrlp-commands` and `:help ctrlp-extensions` for other commands.
 Run `:help ctrlp-mappings` or submit `?` in CtrlP for more mapping help.
 
 * Submit two or more dots `..` to go up the directory tree by one or multiple levels.
-* End the input string with a colon `:` followed by a command to execute it on the opening file(s):  
-Use `:25` to jump to line 25.  
+* End the input string with a colon `:` followed by a command to execute it on the opening file(s):
+Use `:25` to jump to line 25.
 Use `:diffthis` when opening multiple files to run `:diffthis` on the first 4 files.
 
 ## Basic Options
@@ -47,20 +44,27 @@ Use `:diffthis` when opening multiple files to run `:diffthis` on the first 4 fi
     let g:ctrlp_cmd = 'CtrlP'
     ```
 
-* When invoked, unless a starting directory is specified, CtrlP will set its local working directory according to this variable:
+* When invoked without an explicit starting directory, CtrlP will set its local working directory according to this variable:
 
     ```vim
     let g:ctrlp_working_path_mode = 'ra'
     ```
 
     `'c'` - the directory of the current file.  
-    `'r'` - the nearest ancestor that contains one of these directories or files: `.git` `.hg` `.svn` `.bzr` `_darcs`  
-    `'a'` - like c, but only if the current working directory outside of CtrlP is not a direct ancestor of the directory of the current file.  
+    `'a'` - the directory of the current file, unless it is a subdirectory of the cwd  
+    `'r'` - the nearest ancestor of the current file that contains one of these directories or files: `.git` `.hg` `.svn` `.bzr` `_darcs`  
+    `'w'` - modifier to "r": start search from the cwd instead of the current file's directory  
     `0` or `''` (empty string) - disable this feature.
 
-    Define additional root markers with the `g:ctrlp_root_markers` option.
+    If none of the default markers (`.git` `.hg` `.svn` `.bzr` `_darcs`) are present in a project, you can define additional ones with `g:ctrlp_root_markers`:
 
-* Exclude files and directories using Vim's `wildignore` and CtrlP's own `g:ctrlp_custom_ignore`:
+    ```vim
+    let g:ctrlp_root_markers = ['pom.xml', '.p4ignore']
+    ```
+
+    If more than one mode is specified, they will be tried in order until a directory is located.
+
+* Exclude files and directories using Vim's `wildignore` and CtrlP's own `g:ctrlp_custom_ignore`. If a custom listing command is being used, exclusions are ignored:
 
     ```vim
     set wildignore+=*/tmp/*,*.so,*.swp,*.zip     " MacOSX/Linux
@@ -81,11 +85,17 @@ Use `:diffthis` when opening multiple files to run `:diffthis` on the first 4 fi
     let g:ctrlp_user_command = 'dir %s /-n /b /s /a-d'  " Windows
     ```
 
+* Ignore files in `.gitignore`
+    
+    ```vim
+      let g:ctrlp_user_command = ['.git', 'cd %s && git ls-files -co --exclude-standard']
+    ```
+
 Check `:help ctrlp-options` for other options.
 
 ## Installation
 Use your favorite method or check the homepage for a [quick installation guide][3].
 
-[1]: http://i.imgur.com/yIynr.png
-[2]: https://github.com/kien/ctrlp.vim/tree/extensions
-[3]: http://kien.github.com/ctrlp.vim#installation
+[1]: http://i.imgur.com/aOcwHwt.png
+[2]: https://github.com/ctrlpvim/ctrlp.vim/tree/extensions
+[3]: http://ctrlpvim.github.com/ctrlp.vim#installation

--- a/update_plugins.py
+++ b/update_plugins.py
@@ -19,7 +19,7 @@ PLUGINS = """
 ack.vim https://github.com/mileszs/ack.vim
 ag.vim https://github.com/rking/ag.vim
 bufexplorer https://github.com/corntrace/bufexplorer
-ctrlp.vim https://github.com/kien/ctrlp.vim
+ctrlp.vim https://github.com/ctrlpvim/ctrlp.vim
 mayansmoke https://github.com/vim-scripts/mayansmoke
 nerdtree https://github.com/scrooloose/nerdtree
 nginx-vim-syntax https://github.com/evanmiller/nginx-vim-syntax


### PR DESCRIPTION
While I was reading the README file, I found this project still using unmaintained plugin [kien/ctrlp.vim](https://github.com/kien/ctrlp.vim), they suggest switch to the [ctrlpvim/ctrlp.vim](https://github.com/ctrlpvim/ctrlp.vim), which is the current ctrlp.vim active development project.

Please review, thanks.