### PR TITLE
CTRL ignore all gitignore'd files

### DIFF
--- a/vimrcs/plugins_config.vim
+++ b/vimrcs/plugins_config.vim
@@ -47,6 +47,7 @@ map <c-b> :CtrlPBuffer<cr>
 
 let g:ctrlp_max_height = 20
 let g:ctrlp_custom_ignore = 'node_modules\|^\.DS_Store\|^\.git\|^\.coffee'
+let g:ctrlp_user_command = ['.git', 'cd %s && git ls-files -co --exclude-standard']
 
 
 """"""""""""""""""""""""""""""


### PR DESCRIPTION
Taken straight from the docs: https://github.com/ctrlpvim/ctrlp.vim.

1. Ignoring these files **significantly** increases performance (my ctrlp config ignores gitignore files )
2. This will make vim with the behavior of modern text editors, such as atom, sublime, etc.
3. Gitignored files are less likely to be edited so it is okay if they are removed from ctrlp indexing