### PR TITLE
Properly disable sound on errors on MacVim

### DIFF
--- a/vimrcs/basic.vim
+++ b/vimrcs/basic.vim
@@ -131,6 +131,12 @@ set novisualbell
 set t_vb=
 set tm=500
 
+" Properly disable sound on errors on MacVim
+if has("gui_macvim")
+    autocmd GUIEnter * set vb t_vb=
+endif
+
+
 " Add a bit extra margin to the left
 set foldcolumn=1
 


### PR DESCRIPTION
Current configuration was not disabling that annoying sounds on MacVim. According to help:

```
Use visual bell instead of beeping.  The terminal code to display the
	visual bell is given with 't_vb'.  When no beep or flash is wanted,
	use ":set vb t_vb=".
	Note: When the GUI starts, 't_vb' is reset to its default value.  You
	might want to set it again in your |gvimrc|.
```