### PR TITLE
Set HTML syntax for Twig files

### DIFF
--- a/vimrcs/filetypes.vim
+++ b/vimrcs/filetypes.vim
@@ -65,3 +65,9 @@ au FileType gitcommit call setpos('.', [0, 1, 1, 0])
 if exists('$TMUX') 
     set term=screen-256color 
 endif
+
+
+""""""""""""""""""""""""""""""
+" => Twig section
+""""""""""""""""""""""""""""""
+autocmd BufRead *.twig set syntax=html filetype=html


### PR DESCRIPTION
Hello,

First of all, congrats for this awesome configurations.

I usually work with Twig template engine, which is widely used in PHP and its frameworks (Symfony, Silex, etc.). As it's almost just HTML, I've considered a good idea to just set the same syntax defined for HTML.

Hope you find useful.

Best regards,
Julen
