### PR TITLE
Make plugins_config use relative path

### DIFF
--- a/vimrcs/plugins_config.vim
+++ b/vimrcs/plugins_config.vim
@@ -8,8 +8,9 @@
 """"""""""""""""""""""""""""""
 " => Load pathogen paths
 """"""""""""""""""""""""""""""
-call pathogen#infect('~/.vim_runtime/sources_forked/{}')
-call pathogen#infect('~/.vim_runtime/sources_non_forked/{}')
+let s:vim_runtime = expand('<sfile>:p:h')."/.."
+call pathogen#infect(s:vim_runtime.'/sources_forked/{}')
+call pathogen#infect(s:vim_runtime.'/sources_non_forked/{}')
 call pathogen#helptags()
 
 """"""""""""""""""""""""""""""


### PR DESCRIPTION
Hi,

I wanted to move vim_runtime but the plugin folders were using absolute path. 
See here http://stackoverflow.com/a/18734557 more info on the path resolution.
Specifically, there is a warning about symlinks. I suppose it could be a problem.

 