### PR TITLE
Removed let g:mapleader in line 59

### DIFF
--- a/vimrcs/basic.vim
+++ b/vimrcs/basic.vim
@@ -56,7 +56,6 @@ set autoread
 " With a map leader it's possible to do extra key combinations
 " like <leader>w saves the current file
 let mapleader = ","
-let g:mapleader = ","
 
 " Fast saving
 nmap <leader>w :w!<cr>


### PR DESCRIPTION
Since we are already defining mapleader to ",", there is no need to define g:leader as well.

So I removed g:mapleader from the vimrc, to make it simpler.