### PR TITLE
fix(basic.vim): change `command W` to `command! W`

### DIFF
--- a/vimrcs/basic.vim
+++ b/vimrcs/basic.vim
@@ -49,7 +49,7 @@ nmap <leader>w :w!<cr>
 
 " :W sudo saves the file 
 " (useful for handling the permission-denied error)
-command W w !sudo tee % > /dev/null
+command! W w !sudo tee % > /dev/null
 
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""


### PR DESCRIPTION
`source $MYVIMRC` will fail since command `W` exists.
Add `!` so the command would be redefined