### PR TITLE
Update install_awesome_parameterized.sh

### DIFF
--- a/install_awesome_parameterized.sh
+++ b/install_awesome_parameterized.sh
@@ -2,7 +2,6 @@
 set -e
 
 echo 'Installing Awesome Vim from '$1
-cd $1
 
 VIMRC="set runtimepath+=$1
 
@@ -17,12 +16,12 @@ catch
 endtry"
 
 if [ $2 == "--all" ]; then
+    echo "$VIMRC" > /root/.vimrc
+    echo "Installed the Ultimate Vim configuration for user root successfully! Enjoy :-)"
     USERS=($(ls -l /home | awk '{if(NR>1)print $9}'))
     for user in ${USERS[*]}; do
         homepath=$(eval echo "~$user")
-        IFS=''
-        echo $VIMRC > ${homepath}/.vimrc
-        unset IFS
+        echo "$VIMRC" > ${homepath}/.vimrc
         echo "Installed the Ultimate Vim configuration for user $user successfully! Enjoy :-)"
     done
     echo "Installed the Ultimate Vim configuration successfully! Enjoy :-)"
@@ -32,9 +31,7 @@ else
     echo "Selected users: ${SELECTED_USERS[@]}"
     for user in ${SELECTED_USERS[@]}; do
         homepath=$(eval echo "~$user")
-        IFS=''
-        echo $VIMRC > ${homepath}/.vimrc
-        unset IFS
+        echo "$VIMRC" > ${homepath}/.vimrc
         echo "Installed the Ultimate Vim configuration for user $user successfully! Enjoy :-)"
     done
     exit 0


### PR DESCRIPTION
1. Add root for --all.
2. Use "$VIMRC" instead of setting IFS.
3. No need to "cd $1", but $1 must be an absolute path.

The command in "Install for multiple users" needed to be updated:
bash /opt/vim_runtime/install_awesome_parameterized.sh /opt/vim_runtime user0 user1 user2
bash /opt/vim_runtime/install_awesome_parameterized.sh /opt/vim_runtime --all
(Better use bash instead of sh, in consider of sh->dash in debian or ubuntu to avoid "Syntax error")
/opt/vim_runtime can be any directory, as long as all the users specified have read access, but must be an absolute path.