### PR TITLE
Add proper remote for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sources_non_forked/vim-isort"]
+	path = sources_non_forked/vim-isort
+	url = https://github.com/fisadev/vim-isort


### PR DESCRIPTION
I happen to include your project as a submodule under my main tree. While performing `submodule update --recursive`, I noticed that you've added a submodule vim-isort at 1d42b6301371a9f2e0c1c54ef7af50d4a9c7f91a, but there's `.gitmodules` missing in the root directory of repo so git doesn't know what is the remote for vim-isort. I pointed remote for submodule to https://github.com/fisadev/vim-isort which seems to work just fine.