### PR TITLE
fixed a spelling mistake in basic.vim

### DIFF
--- a/vimrcs/basic.vim
+++ b/vimrcs/basic.vim
@@ -163,7 +163,7 @@ set ffs=unix,dos,mac
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " => Files, backups and undo
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-" Turn backup off, since most stuff is in SVN, git et.c anyway...
+" Turn backup off, since most stuff is in SVN, git etc. anyway...
 set nobackup
 set nowb
 set noswapfile


### PR DESCRIPTION
replaced `et.c` with `etc.` in line 166.