### PR TITLE
Fix bug that breaks ctrl-f vi command

### DIFF
--- a/vimrcs/plugins_config.vim
+++ b/vimrcs/plugins_config.vim
@@ -45,7 +45,7 @@ nmap <c-n> <Plug>yankstack_substitute_newer_paste
 """"""""""""""""""""""""""""""
 let g:ctrlp_working_path_mode = 0
 
-let g:ctrlp_map = '<c-f>'
+let g:ctrlp_map = '<c-p>'
 map <leader>j :CtrlP<cr>
 map <c-b> :CtrlPBuffer<cr>
 


### PR DESCRIPTION
A configuration intended for ctrl-p kept setting vi command ctrl-f to something besides page up.