### PR TITLE
fix typo when installing for specific users

### DIFF
--- a/install_awesome_parameterized.sh
+++ b/install_awesome_parameterized.sh
@@ -31,7 +31,7 @@ else
     SELECTED_USERS=${@:2}
     echo "Selected users: $SELECTED_USERS"
     for user in $SELECTED_USERS; do
-        homepath=$(eval echo "~/$user")
+        homepath=$(eval echo "~$user")
         IFS=''
         echo $VIMRC > ${homepath}/.vimrc
         unset IFS


### PR DESCRIPTION
line 34 had `~/$user` which evaluates to `/home/user1/user1`. Now changed into `~$user` as above