### PR TITLE
fix shell command error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ The awesome version includes a lot of great plugins, configurations and color sc
 To install for multiple users, the repository needs to be cloned to a location accessible for all the intended users.
 
 	git clone --depth=1 https://github.com/amix/vimrc.git /opt/vim_runtime
-	sh ~/.vim_runtime/install_awesome_parameterized.sh /opt/vim_runtime user0 user1 user2
+	sh /opt/vim_runtime/install_awesome_parameterized.sh /opt/vim_runtime user0 user1 user2
 	# to install for all users with home directories
-	sh ~/.vim_runtime/install_awesome_parameterized.sh /opt/vim_runtime --all
+	sh /opt/vim_runtime/install_awesome_parameterized.sh /opt/vim_runtime --all
 	
 Naturally, `/opt/vim_runtime` can be any directory, as long as all the users specified have read access.
 


### PR DESCRIPTION
Change `~/.vim_runtime` to `/opt/vim_runtime`.