### PR TITLE
Save old vimrc before writing into them

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The awesome version includes a lot of great plugins, configurations and color sc
 
 	git clone --depth=1 https://github.com/amix/vimrc.git ~/.vim_runtime
 	sh ~/.vim_runtime/install_awesome_vimrc.sh
-	
+
 ### Install for multiple users
 To install for multiple users, the repository needs to be cloned to a location accessible for all the intended users.
 
@@ -26,7 +26,7 @@ To install for multiple users, the repository needs to be cloned to a location a
 	sh ~/.vim_runtime/install_awesome_parameterized.sh /opt/vim_runtime user0 user1 user2
 	# to install for all users with home directories
 	sh ~/.vim_runtime/install_awesome_parameterized.sh /opt/vim_runtime --all
-	
+
 Naturally, `/opt/vim_runtime` can be any directory, as long as all the users specified have read access.
 
 ## Fonts
@@ -87,11 +87,11 @@ I recommend reading the docs of these plugins to understand them better. Each pl
 * [ack.vim](https://github.com/mileszs/ack.vim): Vim plugin for `the_silver_searcher` (ag) or ack -- a wicked fast grep
 * [bufexplorer.zip](https://github.com/vim-scripts/bufexplorer.zip): Quickly and easily switch between buffers. This plugin can be opened with `<leader+o>`
 * [ctrlp.vim](https://github.com/ctrlpvim/ctrlp.vim): Fuzzy file, buffer, mru and tag finder. It's mapped to `<Ctrl+F>`
-* [goyo.vim](https://github.com/junegunn/goyo.vim) and [vim-zenroom2](https://github.com/amix/vim-zenroom2): 
+* [goyo.vim](https://github.com/junegunn/goyo.vim) and [vim-zenroom2](https://github.com/amix/vim-zenroom2):
 * [lightline.vim](https://github.com/itchyny/lightline.vim): A light and configurable statusline/tabline for Vim
 * [NERD Tree](https://github.com/scrooloose/nerdtree): A tree explorer plugin for vim
 * [open_file_under_cursor.vim](https://github.com/amix/open_file_under_cursor.vim): Open file under cursor when pressing `gf`
-* [pathogen.vim](https://github.com/tpope/vim-pathogen): Manage your vim runtimepath 
+* [pathogen.vim](https://github.com/tpope/vim-pathogen): Manage your vim runtimepath
 * [snipmate.vim](https://github.com/garbas/vim-snipmate): snipmate.vim aims to be a concise vim script that implements some of TextMate's snippets features in Vim
 * [ale](https://github.com/w0rp/ale): Syntax and lint checking for vim (ALE requires NeoVim >= 0.2.0 or Vim 8 with +timers +job +channel)
 * [vim-commentary](https://github.com/tpope/vim-commentary): Comment stuff out.  Use `gcc` to comment out a line (takes a count), `gc` to comment out the target of a motion. `gcu` uncomments a set of adjacent commented lines.
@@ -133,7 +133,7 @@ After you have installed the setup, you can create **~/.vim_runtime/my_configs.v
 
 	~/.vim_runtime (master)> cat my_configs.vim
 	map <leader>ct :cd ~/Desktop/Todoist/todoist<cr>
-	map <leader>cw :cd ~/Desktop/Wedoist/wedoist<cr> 
+	map <leader>cw :cd ~/Desktop/Wedoist/wedoist<cr>
 
 You can also install your plugins, for instance, via pathogen you can install [vim-rails](https://github.com/tpope/vim-rails):
 
@@ -151,57 +151,57 @@ The [leader](http://learnvimscriptthehardway.stevelosh.com/chapters/06.html#lead
 Fast saving of a buffer (`<leader>w`):
 
 	nmap <leader>w :w!<cr>
-	
+
 Map `<Space>` to `/` (search) and `<Ctrl>+<Space>` to `?` (backwards search):
-	
+
 	map <space> /
 	map <C-space> ?
 	map <silent> <leader><cr> :noh<cr>
 
 Disable highlights when you press `<leader><cr>`:
-	
+
 	map <silent> <leader><cr> :noh<cr>
 
 Smart way to move between windows (`<ctrl>j` etc.):
-	
+
 	map <C-j> <C-W>j
 	map <C-k> <C-W>k
 	map <C-h> <C-W>h
 	map <C-l> <C-W>l
 
 Closing of the current buffer(s) (`<leader>bd` and (`<leader>ba`)):
-	
+
 	" Close current buffer
 	map <leader>bd :Bclose<cr>
-	
+
 	" Close all buffers
 	map <leader>ba :1,1000 bd!<cr>
-	
+
 Useful mappings for managing tabs:
-	
+
 	map <leader>tn :tabnew<cr>
 	map <leader>to :tabonly<cr>
 	map <leader>tc :tabclose<cr>
-	map <leader>tm :tabmove 
-	
+	map <leader>tm :tabmove
+
 	" Opens a new tab with the current buffer's path
 	" Super useful when editing files in the same directory
 	map <leader>te :tabedit <C-r>=expand("%:p:h")<cr>/
-	
+
 Switch [CWD](http://vim.wikia.com/wiki/Set_working_directory_to_the_current_file) to the directory of the open buffer:
-	
+
 	map <leader>cd :cd %:p:h<cr>:pwd<cr>
-	
+
 Open `ack.vim` for fast search:
-	
-	map <leader>g :Ack 
+
+	map <leader>g :Ack
 
 Quickly open a buffer for scripbble:
-	
+
 	map <leader>q :e ~/buffer<cr>
 
 Toggle paste mode on and off:
-	
+
 	map <leader>pp :setlocal paste!<cr>
 
 
@@ -264,13 +264,13 @@ Bash like keys for the command line:
 
 Write the file as sudo (works only on Unix). Super useful when you open a file and you don't have permissions to save your changes. [Vim tip](http://vim.wikia.com/wiki/Su-write):
 
-    :W 
+    :W
 
 
 ### Plugin related mappings
 
 Open [bufexplorer](https://github.com/vim-scripts/bufexplorer.zip) to see and manage the current buffers (`<leader>o`):
-    
+
     map <leader>o :BufExplorer<cr>
 
 Open [ctrlp.vim](https://github.com/kien/ctrlp.vim) plugin to quickly find a file or a buffer (`<leader>j` or `<ctrl>f`):
@@ -287,7 +287,7 @@ Open [ctrlp.vim](https://github.com/kien/ctrlp.vim) plugin to quickly find a fil
 [NERD Tree](https://github.com/scrooloose/nerdtree) mappings:
 
     map <leader>nn :NERDTreeToggle<cr>
-    map <leader>nb :NERDTreeFromBookmark 
+    map <leader>nb :NERDTreeFromBookmark
     map <leader>nf :NERDTreeFind<cr>
 
 [goyo.vim](https://github.com/junegunn/goyo.vim) and [vim-zenroom2](https://github.com/amix/vim-zenroom2) lets you only focus on one thing at a time. It removes all the distractions and centers the content. It has a special look when editing Markdown, reStructuredText and textfiles. It only has one mapping. (`<leader>z`)

--- a/install_basic_vimrc.sh
+++ b/install_basic_vimrc.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+# Save previous vimrc.
+if [ -f $HOME/.vimrc ]; then
+    mv ~/.vimrc ~/.oldvimrc
+    echo "Saved previous vimrc as $HOME/.oldvimrc"
+fi
 cd ~/.vim_runtime
 cat ~/.vim_runtime/vimrcs/basic.vim > ~/.vimrc
 echo "Installed the Basic Vim configuration successfully! Enjoy :-)"


### PR DESCRIPTION
Current installation script overwrites whatever is present in vimrc. Purpose of his PR is to save old configs (if present) as `$HOME/.oldvimrc` and then write into new vimrc.

Also remove whitespaces from README. Those having an OCD will be satisfied :)