### PR TITLE
improve README instructions for installing updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Just do a git rebase!
     git pull --rebase
     python update_plugins.py
 
+NOTE: If you get `ModuleNotFoundError: No module named 'requests'`, you must first install the `requests` python module using `pip`, `pip3`, or `easy_install`.
+
+    pip3 install requests
 
 ## Some screenshots
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Just do a git rebase!
 
 NOTE: If you get `ModuleNotFoundError: No module named 'requests'`, you must first install the `requests` python module using `pip`, `pip3`, or `easy_install`.
 
-    pip3 install requests
+    pip install requests
 
 ## Some screenshots
 


### PR DESCRIPTION
## What

The following error occurs when calling `python update_plugins.py` on a fresh install of vimrc and python that does not yet have the `requests` module installed.

```
Traceback (most recent call last):
  File "/Users/basti/.vim_runtime/update_plugins.py", line 12, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```

## Why

The `requests` python module is not included by default and must be installed manually before `python update_plugins.py` will work properly.