### PR TITLE
[snipMate] set to default version 1

### DIFF
--- a/vimrcs/plugins_config.vim
+++ b/vimrcs/plugins_config.vim
@@ -72,6 +72,7 @@ let g:user_zen_mode='a'
 """"""""""""""""""""""""""""""
 ino <C-j> <C-r>=snipMate#TriggerSnippet()<cr>
 snor <C-j> <esc>i<right><C-r>=snipMate#TriggerSnippet()<cr>
+let g:snipMate = { 'snippet_version' : 1 }
 
 
 """"""""""""""""""""""""""""""


### PR DESCRIPTION
Fix the annoying error message about the SnipMate version 0 deprecation

```
$ vim foo
The legacy SnipMate parser is deprecated. Please see :h SnipMate-deprecate.
Press ENTER or type command to continue
```

With this commit, version 1 is now default.