### PR TITLE
Add conditional branches to mapleader

### DIFF
--- a/install_awesome_vimrc.sh
+++ b/install_awesome_vimrc.sh
@@ -5,6 +5,11 @@ cd ~/.vim_runtime
 
 echo 'set runtimepath+=~/.vim_runtime
 
+try
+source ~/.vim_runtime/eden_configs.vim
+catch
+endtry
+
 source ~/.vim_runtime/vimrcs/basic.vim
 source ~/.vim_runtime/vimrcs/filetypes.vim
 source ~/.vim_runtime/vimrcs/plugins_config.vim

--- a/vimrcs/basic.vim
+++ b/vimrcs/basic.vim
@@ -42,8 +42,16 @@ set autoread
 au FocusGained,BufEnter * checktime
 
 " With a map leader it's possible to do extra key combinations
-" like <leader>w saves the current file
-let mapleader = ","
+" like <leader>w saves the current file.
+" To override this behavior and set it back to '\' (or any other
+" character) add the following to your ~/.vim_runtime/eden_configs.vim file:
+"   let g:amix_leader='\'
+"  The method comes from sfp13/spf13-vim.
+if !exists('g:amix_leader')
+	let mapleader = ','
+else
+	let mapleader=g:amix_leader
+endif
 
 " Fast saving
 nmap <leader>w :w!<cr>


### PR DESCRIPTION
By introducing a new file `eden_configs.vim` and adding **conditional branches** to `basic.vim`, we can customize mapleader without modifying the file `basic.vim`.