### PR TITLE
install error fix

### DIFF
--- a/vimrcs/basic.vim
+++ b/vimrcs/basic.vim
@@ -140,7 +140,7 @@ if $COLORTERM == 'gnome-terminal'
 endif
 
 try
-    colorscheme desert
+    colorscheme bruh
 catch
 endtry
 


### PR DESCRIPTION
desert colorscheme name that gave error was bruh.
![image](https://user-images.githubusercontent.com/75628379/108996155-1c3c4b80-76af-11eb-9d52-868b83fbc1fa.png)
