### PR TITLE
🚑 Fix cpp and c files run

### DIFF
--- a/vimrcs/extended.vim
+++ b/vimrcs/extended.vim
@@ -207,18 +207,16 @@ vmap <F5> <Esc>:call CompileRun()<CR>
 func! CompileRun()
 exec "w"
 if &filetype == 'c'
-    exec "!gcc % -o %<"
-    exec "!time ./%<"
+    exec "!gcc % && ./a.out<"
 elseif &filetype == 'cpp'
-    exec "!g++ % -o %<"
-    exec "!time ./%<"
+    exec "!g++ % && ./a.out"
 elseif &filetype == 'java'
     exec "!javac %"
     exec "!time java %"
 elseif &filetype == 'sh'
     exec "!time bash %"
 elseif &filetype == 'python'
-    exec "!time python3 %"
+    exec "!time python %"
 elseif &filetype == 'html'
     exec "!google-chrome % &"
 elseif &filetype == 'go'


### PR DESCRIPTION
1. Fix bug in running c and cpp files. (bug: after run c or cpp file, you directly go to vim editor without seeing a result of running files. To see the result, you need to run any command starting with `:!` to go terminal and see previous result)
2. Create only one file (a.out) to any cpp or c files. If you run several cpp/c files, you will create several .out files instead of one a.out file(main.cpp --> main.out, c.cpp --> c.out etc.). After this pull request, each run c/cpp files will create only one a.out file.
3. 
