### PR TITLE
plugin update change repo

### DIFF
--- a/update_plugins.py
+++ b/update_plugins.py
@@ -17,13 +17,13 @@ from os import path
 # --- Globals ----------------------------------------------
 PLUGINS = """
 auto-pairs https://github.com/jiangmiao/auto-pairs
-ale https://github.com/w0rp/ale
+ale https://github.com/dense-analysis/ale
 vim-yankstack https://github.com/maxbrunsfeld/vim-yankstack
 ack.vim https://github.com/mileszs/ack.vim
 bufexplorer https://github.com/jlanzarotta/bufexplorer
 ctrlp.vim https://github.com/ctrlpvim/ctrlp.vim
 mayansmoke https://github.com/vim-scripts/mayansmoke
-nerdtree https://github.com/scrooloose/nerdtree
+nerdtree https://github.com/preservim/nerdtree
 nginx.vim https://github.com/chr4/nginx.vim
 open_file_under_cursor.vim https://github.com/amix/open_file_under_cursor.vim
 tlib https://github.com/tomtom/tlib_vim
@@ -50,7 +50,7 @@ vim-flake8 https://github.com/nvie/vim-flake8
 vim-pug https://github.com/digitaltoad/vim-pug
 lightline.vim https://github.com/itchyny/lightline.vim
 lightline-ale https://github.com/maximbaz/lightline-ale
-vim-abolish https://github.com/tpope/tpope-vim-abolish
+vim-abolish https://github.com/tpope/vim-abolish
 rust.vim https://github.com/rust-lang/rust.vim
 vim-markdown https://github.com/plasticboy/vim-markdown
 vim-gist https://github.com/mattn/vim-gist


### PR DESCRIPTION
The original update_plugins.py should work fine, but if I use an accelerated domain name (like https://github.com.cnpmjs.org/), it will not automatically redirect to the new repo address. Therefore I updated the plugins repo to the new ones.
![Screenshot from 2021-08-14 08-17-55](https://user-images.githubusercontent.com/11880269/129428680-d1f9ba04-9b96-44bb-8357-b15a7cd06edf.png)
