### PR TITLE
fix: escape spaces in expanded paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Useful mappings for managing tabs:
 	
 	" Opens a new tab with the current buffer's path
 	" Super useful when editing files in the same directory
-	map <leader>te :tabedit <C-r>=expand("%:p:h")<cr>/
+	map <leader>te :tabedit <C-r>=escape(expand("%:p:h"), " ")<cr>/
 	
 Switch [CWD](http://vim.wikia.com/wiki/Set_working_directory_to_the_current_file) to the directory of the open buffer:
 	

--- a/vimrcs/basic.vim
+++ b/vimrcs/basic.vim
@@ -241,7 +241,7 @@ au TabLeave * let g:lasttab = tabpagenr()
 
 " Opens a new tab with the current buffer's path
 " Super useful when editing files in the same directory
-map <leader>te :tabedit <C-r>=expand("%:p:h")<cr>/
+map <leader>te :tabedit <C-r>=escape(expand("%:p:h"), " ")<cr>/
 
 " Switch CWD to the directory of the open buffer
 map <leader>cd :cd %:p:h<cr>:pwd<cr>

--- a/vimrcs/extended.vim
+++ b/vimrcs/extended.vim
@@ -170,7 +170,7 @@ func! DeleteTillSlash()
 endfunc
 
 func! CurrentFileDir(cmd)
-    return a:cmd . " " . expand("%:p:h") . "/"
+    return a:cmd . " " . escape(expand("%:p:h"), " ") . "/"
 endfunc
 
 "=================================================================================


### PR DESCRIPTION
I know, no one should use spaces in paths, but if anyone does this PR escapes them. 😉 