### PR TITLE
Replace python-requests with urllib.request

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,6 @@ Just do a git rebase!
     git pull --rebase
     python update_plugins.py  # use python3 if python is unavailable
 
-NOTE: If you get `ModuleNotFoundError: No module named 'requests'`, you must first install the `requests` python module using `pip`, `pip3`, or `easy_install`.
-
-    pip install requests
-
 ## Some screenshots
 
 Colors when editing a Python file:

--- a/update_plugins.py
+++ b/update_plugins.py
@@ -7,11 +7,11 @@ except ImportError:
         futures = None
 
 import re
-import zipfile
 import shutil
 import tempfile
-import requests
-
+import urllib.request
+import zipfile
+from io import BytesIO
 from os import path
 
 # --- Globals ----------------------------------------------
@@ -71,16 +71,12 @@ SOURCE_DIR = path.join(path.dirname(__file__), "sources_non_forked")
 
 
 def download_extract_replace(plugin_name, zip_path, temp_dir, source_dir):
-    temp_zip_path = path.join(temp_dir, plugin_name)
-
     # Download and extract file in temp dir
-    req = requests.get(zip_path)
-    open(temp_zip_path, "wb").write(req.content)
+    with urllib.request.urlopen(zip_path) as req:
+        zip_f = zipfile.ZipFile(BytesIO(req.read()))
+        zip_f.extractall(temp_dir)
+        content_disp = req.headers.get("Content-Disposition")
 
-    zip_f = zipfile.ZipFile(temp_zip_path)
-    zip_f.extractall(temp_dir)
-
-    content_disp = req.headers.get("Content-Disposition")
     filename = re.findall("filename=(.+).zip", content_disp)[0]
     plugin_temp_path = path.join(temp_dir, path.join(temp_dir, filename))
 


### PR DESCRIPTION
## Changes

Replaced **python-requests** with **urllib.request** from the standard library; for simple GET requests, both urllib and requests are equal in terms of boilerplate and performance, so this saves us the extra step of `pip install requests`.

`README.md` has been updated accordingly.