### PR TITLE
Fix autocommand error when opening command line window

### DIFF
--- a/vimrcs/basic.vim
+++ b/vimrcs/basic.vim
@@ -39,7 +39,7 @@ filetype indent on
 
 " Set to auto read when a file is changed from the outside
 set autoread
-au FocusGained,BufEnter * checktime
+au FocusGained,BufEnter * silent! checktime
 
 " With a map leader it's possible to do extra key combinations
 " like <leader>w saves the current file


### PR DESCRIPTION
Closes #729

Source: <https://morgan.cugerone.com/blog/troubleshooting-vim-error-while-processing-cursorhold-autocommands-in-command-line-window>