### PR TITLE
Fix support for native vim packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ You can also install your plugins, for instance, via pathogen you can install [v
 
 You can also install plugins without any plugin manager (vim 8+ required):
 
-* Add `packloadall` to your `.vimrc` file
 * Create pack plugin directory:\
 `mkdir -p ~/.vim_runtime/pack/plugins/start`
 * Clone the plugin that you want in that directory, for example:\

--- a/vimrcs/plugins_config.vim
+++ b/vimrcs/plugins_config.vim
@@ -6,6 +6,12 @@
 
 
 """"""""""""""""""""""""""""""
+" => Enable native vim packages as described in the README
+""""""""""""""""""""""""""""""
+set packpath+=~/.vim_runtime
+
+
+""""""""""""""""""""""""""""""
 " => Load pathogen paths
 """"""""""""""""""""""""""""""
 let s:vim_runtime = expand('<sfile>:p:h')."/.."


### PR DESCRIPTION
Make native packages easier to setup.

Tested on

```
VIM - Vi IMproved 9.0 (2022 Jun 28, compiled Apr 15 2023 04:26:05)
macOS version - x86_64
Included patches: 1-1424
Compiled by root@apple.com
```

and

```
VIM - Vi IMproved 8.2 (2019 Dec 12, compiled Oct 01 2021 01:51:08)
Included patches: 1-2434
Extra patches: 8.2.3402, 8.2.3403, 8.2.3409, 8.2.3428
Modified by team+vim@tracker.debian.org
Compiled by team+vim@tracker.debian.org
```