### PR TITLE
Fix broken code block in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ nmap <C-n> <Plug>yankstack_substitute_newer_paste
 let g:ctrlp_map = '<C-f>'
 map <leader>j :CtrlP<cr>
 map <C-b> :CtrlPBuffer<cr>
+```
 
 [vim-snipmate](https://github.com/garbas/vim-snipmate) mappings to autocomplete via snippets:
 ```vim


### PR DESCRIPTION
Adds missing closing code fence in README.md to fix incorrect formatting of vim-snipmate mappings.