### PR TITLE
Add Python 3 required statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ If you have vim aliased as `vi` instead of `vim`, make sure to either alias it: 
 
 ## How to update to latest version?
 
-Just do a git rebase!
-
+Just do a git rebase! Python 3 is required.
 
     cd ~/.vim_runtime
     git reset --hard


### PR DESCRIPTION
From #740, Python 2 is no longer supported. This line `python update_plugins.py  # use python3 if python is unavailable` makes it sound like this script still supports Python 2. So a `Python 3 is required.` statement clears up that ambiguity.

---

The current **update_plugins.py** script will not run on Python 2 because of the use of **urllib.request.urlopen** (Python 2 uses **urllib2** module for the **urlopen** method), and in Python 2, **urllib2.urlopen** needs **contextlib.closing** to be used in a `with` clause.