### PR TITLE
ISSUE-767 - default inoremap breaks shell, php, perl coding

### DIFF
--- a/vimrcs/extended.vim
+++ b/vimrcs/extended.vim
@@ -87,13 +87,14 @@ vnoremap $$ <esc>`>a"<esc>`<i"<esc>
 vnoremap $q <esc>`>a'<esc>`<i'<esc>
 vnoremap $e <esc>`>a`<esc>`<i`<esc>
 
+" Breaks shell, perl, php... coding
 " Map auto complete of (, ", ', [
-inoremap $1 ()<esc>i
-inoremap $2 []<esc>i
-inoremap $3 {}<esc>i
-inoremap $4 {<esc>o}<esc>O
-inoremap $q ''<esc>i
-inoremap $e ""<esc>i
+" inoremap $1 ()<esc>i
+" inoremap $2 []<esc>i
+" inoremap $3 {}<esc>i
+" inoremap $4 {<esc>o}<esc>O
+" inoremap $q ''<esc>i
+" inoremap $e ""<esc>i
 
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""


### PR DESCRIPTION
Per issue description, this comments out the global inoremap of "$" aliases to prevent annoying remaps during coding in shell, perl, php and anything else that uses $ for variable declarations (or even just typing in money values).
Not sure why an alias is needed for curlys/brackets, its quicker to just hit those keys on a "normal" keyboard anyway, and auto-close is handled with other remaps.
If they are useful for some other macro/language/remap, they should go in specific envs for that situation, not the global one.